### PR TITLE
Added elements definitions to all datatypes

### DIFF
--- a/pages/_includes/header.html
+++ b/pages/_includes/header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>{{page.title}}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -32,6 +32,3 @@
 <div class="row">
 <div class="inner-wrapper">
 <div class="col-9">
-
-
-

--- a/resources/AD.xml
+++ b/resources/AD.xml
@@ -28,6 +28,7 @@
   <snapshot>
     <element id="AD">
       <path value="AD"/>
+      <definition value="Mailing and home or office addresses. A sequence of address parts, such as street or post office Box, city, postal code, country, etc."/>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -53,6 +54,7 @@
     </element>
     <element id="AD.delimiter">
       <path value="AD.delimiter"/>
+      <definition value="Delimiters are printed without framing white space. If no value component is provided, the delimiter appears as a line break."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -64,8 +66,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.delimiter.partType">
+      <path value="AD.delimiter.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.delimiter.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DEL"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.country">
       <path value="AD.country"/>
+      <definition value="Country"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -77,8 +96,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.country.partType">
+      <path value="AD.country.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.country.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CNT"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.state">
       <path value="AD.state"/>
+      <definition value="A sub-unit of a country with limited sovereignty in a federally organized country."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -90,8 +126,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.state.partType">
+      <path value="AD.state.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.state.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STA"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.county">
       <path value="AD.county"/>
+      <definition value="A sub-unit of a state or province. (49 of the United States of America use the term &quot;county;&quot; Louisiana uses the term &quot;parish&quot;.)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -103,8 +156,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.county.partType">
+      <path value="AD.county.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.county.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CPA"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.city">
       <path value="AD.city"/>
+      <definition value="The name of the city, town, village, or other community or delivery center"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -116,8 +186,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.city.partType">
+      <path value="AD.city.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.city.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CTY"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.postalCode">
       <path value="AD.postalCode"/>
+      <definition value="A postal code designating a region defined by the postal service."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -129,8 +216,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.postalCode.partType">
+      <path value="AD.postalCode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postalCode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="ZIP"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.streetAddressLine">
       <path value="AD.streetAddressLine"/>
+      <definition value="Street address line"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -142,8 +246,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.streetAddressLine.partType">
+      <path value="AD.streetAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="SAL"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.houseNumber">
       <path value="AD.houseNumber"/>
+      <definition value="The number of a building, house or lot alongside the street. Also known as &quot;primary street number&quot;. This does not number the street but rather the building."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -155,8 +276,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.houseNumber.partType">
+      <path value="AD.houseNumber.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumber.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNR"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.houseNumberNumeric">
       <path value="AD.houseNumberNumeric"/>
+      <definition value="The numeric portion of a building number"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -168,8 +306,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.houseNumberNumeric.partType">
+      <path value="AD.houseNumberNumeric.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumberNumeric.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNN"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.direction">
       <path value="AD.direction"/>
+      <definition value="Direction (e.g., N, S, W, E)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -181,8 +336,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.direction.partType">
+      <path value="AD.direction.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.direction.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DIR"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.streetName">
       <path value="AD.streetName"/>
+      <definition value="Name of a roadway or artery recognized by a municipality (including street type and direction)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -194,8 +366,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.streetName.partType">
+      <path value="AD.streetName.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetName.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STR"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.streetNameBase">
       <path value="AD.streetNameBase"/>
+      <definition value="The base name of a roadway or artery recognized by a municipality (excluding street type and direction)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -207,8 +396,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.streetNameBase.partType">
+      <path value="AD.streetNameBase.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameBase.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STB"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.streetNameType">
       <path value="AD.streetNameType"/>
+      <definition value="The designation given to the street. (e.g. Street, Avenue, Crescent, etc.)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -220,8 +426,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.streetNameType.partType">
+      <path value="AD.streetNameType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STTYP"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.additionalLocator">
       <path value="AD.additionalLocator"/>
+      <definition value="This can be a unit designator, such as apartment number, suite number, or floor. There may be several unit designators in an address (e.g., &quot;3rd floor, Appt. 342&quot;). This can also be a designator pointing away from the location, rather than specifying a smaller location within some larger one (e.g., Dutch &quot;t.o.&quot; means &quot;opposite to&quot; for house boats located across the street facing houses)."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -233,8 +456,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.additionalLocator.partType">
+      <path value="AD.additionalLocator.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.additionalLocator.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="ADL"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.unitID">
       <path value="AD.unitID"/>
+      <definition value="The number or name of a specific unit contained within a building or complex, as assigned by that building or complex."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -246,8 +486,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.unitID.partType">
+      <path value="AD.unitID.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitID.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="UNID"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.unitType">
       <path value="AD.unitType"/>
+      <definition value="Indicates the type of specific unit contained within a building or complex. E.g. Appartment, Floor"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -259,8 +516,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.unitType.partType">
+      <path value="AD.unitType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="UNIT"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.careOf">
       <path value="AD.careOf"/>
+      <definition value="The name of the party who will take receipt at the specified address, and will take on responsibility for ensuring delivery to the target recipient"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -272,8 +546,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.careOf.partType">
+      <path value="AD.careOf.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.careOf.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CAR"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.censusTract">
       <path value="AD.censusTract"/>
+      <definition value="A geographic sub-unit delineated for demographic purposes."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -285,8 +576,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.censusTract.partType">
+      <path value="AD.censusTract.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.censusTract.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CEN"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryAddressLine">
       <path value="AD.deliveryAddressLine"/>
+      <definition value="A delivery address line is frequently used instead of breaking out delivery mode, delivery installation, etc. An address generally has only a delivery address line or a street address line, but not both."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -298,8 +606,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryAddressLine.partType">
+      <path value="AD.deliveryAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DAL"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryInstallationType">
       <path value="AD.deliveryInstallationType"/>
+      <definition value="Indicates the type of delivery installation (the facility to which the mail will be delivered prior to final shipping via the delivery mode.) Example: post office, letter carrier depot, community mail center, station, etc."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -311,8 +636,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryInstallationType.partType">
+      <path value="AD.deliveryInstallationType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINST"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryInstallationArea">
       <path value="AD.deliveryInstallationArea"/>
+      <definition value="The location of the delivery installation, usually a town or city, and is only required if the area is different from the municipality. Area to which mail delivery service is provided from any postal facility or service such as an individual letter carrier, rural route, or postal route."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -324,8 +666,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryInstallationArea.partType">
+      <path value="AD.deliveryInstallationArea.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationArea.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINSTA"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryInstallationQualifier">
       <path value="AD.deliveryInstallationQualifier"/>
+      <definition value="A number, letter or name identifying a delivery installation. E.g., for Station A, the delivery installation qualifier would be 'A'."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -337,8 +696,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryInstallationQualifier.partType">
+      <path value="AD.deliveryInstallationQualifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationQualifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINSTQ"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryMode">
       <path value="AD.deliveryMode"/>
+      <definition value="Indicates the type of service offered, method of delivery. For example: post office box, rural route, general delivery, etc."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -350,8 +726,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryMode.partType">
+      <path value="AD.deliveryMode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryMode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DMOD"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.deliveryModeIdentifier">
       <path value="AD.deliveryModeIdentifier"/>
+      <definition value="Represents the routing information such as a letter carrier route number. It is the identifying number of the designator (the box number or rural route number)."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -363,8 +756,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.deliveryModeIdentifier.partType">
+      <path value="AD.deliveryModeIdentifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryModeIdentifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DMODID"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.buildingNumberSuffix">
       <path value="AD.buildingNumberSuffix"/>
+      <definition value="Any alphabetic character, fraction or other text that may appear after the numeric portion of a building number"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -376,8 +786,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.buildingNumberSuffix.partType">
+      <path value="AD.buildingNumberSuffix.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.buildingNumberSuffix.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNS"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.postBox">
       <path value="AD.postBox"/>
+      <definition value="A numbered box located in a post station."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -389,8 +816,25 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.postBox.partType">
+      <path value="AD.postBox.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postBox.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="POB"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.precinct">
       <path value="AD.precinct"/>
+      <definition value="A subsection of a municipality"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -402,9 +846,26 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.precinct.partType">
+      <path value="AD.precinct.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.precinct.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="PRE"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.other">
       <path value="AD.other"/>
       <representation value="xmlText"/>
+      <definition value="Textual representation of (part of) the address"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -480,230 +941,831 @@
   <differential>
     <element id="AD">
       <path value="AD"/>
+      <definition value="Mailing and home or office addresses. A sequence of address parts, such as street or post office Box, city, postal code, country, etc."/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="AD.delimiter">
       <path value="AD.delimiter"/>
+      <definition value="Delimiters are printed without framing white space. If no value component is provided, the delimiter appears as a line break."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.delimiter"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.delimiter.partType">
+      <path value="AD.delimiter.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.delimiter.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DEL"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.country">
       <path value="AD.country"/>
+      <definition value="Country"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.country"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.country.partType">
+      <path value="AD.country.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.country.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CNT"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.state">
       <path value="AD.state"/>
+      <definition value="A sub-unit of a country with limited sovereignty in a federally organized country."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.state"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.state.partType">
+      <path value="AD.state.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.state.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STA"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.county">
       <path value="AD.county"/>
+      <definition value="A sub-unit of a state or province. (49 of the United States of America use the term &quot;county;&quot; Louisiana uses the term &quot;parish&quot;.)"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.county"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.county.partType">
+      <path value="AD.county.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.county.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CPA"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.city">
       <path value="AD.city"/>
+      <definition value="The name of the city, town, village, or other community or delivery center"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.city"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.city.partType">
+      <path value="AD.city.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.city.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CTY"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.postalCode">
       <path value="AD.postalCode"/>
+      <definition value="A postal code designating a region defined by the postal service."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.postalCode"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.postalCode.partType">
+      <path value="AD.postalCode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postalCode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="ZIP"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.streetAddressLine">
       <path value="AD.streetAddressLine"/>
+      <definition value="Street address line"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.streetAddressLine"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetAddressLine.partType">
+      <path value="AD.streetAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="SAL"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.houseNumber">
       <path value="AD.houseNumber"/>
+      <definition value="The number of a building, house or lot alongside the street. Also known as &quot;primary street number&quot;. This does not number the street but rather the building."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.houseNumber"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.houseNumber.partType">
+      <path value="AD.houseNumber.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumber.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNR"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.houseNumberNumeric">
       <path value="AD.houseNumberNumeric"/>
+      <definition value="The numeric portion of a building number"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.houseNumberNumeric"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.houseNumberNumeric.partType">
+      <path value="AD.houseNumberNumeric.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumberNumeric.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNN"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.direction">
       <path value="AD.direction"/>
+      <definition value="Direction (e.g., N, S, W, E)"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.direction"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.direction.partType">
+      <path value="AD.direction.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.direction.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DIR"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.streetName">
       <path value="AD.streetName"/>
+      <definition value="Name of a roadway or artery recognized by a municipality (including street type and direction)"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.streetName"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetName.partType">
+      <path value="AD.streetName.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetName.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STR"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.streetNameBase">
       <path value="AD.streetNameBase"/>
+      <definition value="The base name of a roadway or artery recognized by a municipality (excluding street type and direction)"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.streetNameBase"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetNameBase.partType">
+      <path value="AD.streetNameBase.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameBase.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STB"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.streetNameType">
       <path value="AD.streetNameType"/>
+      <definition value="The designation given to the street. (e.g. Street, Avenue, Crescent, etc.)"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.streetNameType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetNameType.partType">
+      <path value="AD.streetNameType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="STTYP"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.additionalLocator">
       <path value="AD.additionalLocator"/>
+      <definition value="This can be a unit designator, such as apartment number, suite number, or floor. There may be several unit designators in an address (e.g., &quot;3rd floor, Appt. 342&quot;). This can also be a designator pointing away from the location, rather than specifying a smaller location within some larger one (e.g., Dutch &quot;t.o.&quot; means &quot;opposite to&quot; for house boats located across the street facing houses)."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.additionalLocator"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.additionalLocator.partType">
+      <path value="AD.additionalLocator.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.additionalLocator.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="ADL"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.unitID">
       <path value="AD.unitID"/>
+      <definition value="The number or name of a specific unit contained within a building or complex, as assigned by that building or complex."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.unitID"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.unitID.partType">
+      <path value="AD.unitID.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitID.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="UNID"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.unitType">
       <path value="AD.unitType"/>
+      <definition value="Indicates the type of specific unit contained within a building or complex. E.g. Appartment, Floor"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.unitType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.unitType.partType">
+      <path value="AD.unitType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="UNIT"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.careOf">
       <path value="AD.careOf"/>
+      <definition value="The name of the party who will take receipt at the specified address, and will take on responsibility for ensuring delivery to the target recipient"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.careOf"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.careOf.partType">
+      <path value="AD.careOf.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.careOf.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CAR"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.censusTract">
       <path value="AD.censusTract"/>
+      <definition value="A geographic sub-unit delineated for demographic purposes."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.censusTract"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.censusTract.partType">
+      <path value="AD.censusTract.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.censusTract.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="CEN"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryAddressLine">
       <path value="AD.deliveryAddressLine"/>
+      <definition value="A delivery address line is frequently used instead of breaking out delivery mode, delivery installation, etc. An address generally has only a delivery address line or a street address line, but not both."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryAddressLine"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryAddressLine.partType">
+      <path value="AD.deliveryAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DAL"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationType">
       <path value="AD.deliveryInstallationType"/>
+      <definition value="Indicates the type of delivery installation (the facility to which the mail will be delivered prior to final shipping via the delivery mode.) Example: post office, letter carrier depot, community mail center, station, etc."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationType.partType">
+      <path value="AD.deliveryInstallationType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINST"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationArea">
       <path value="AD.deliveryInstallationArea"/>
+      <definition value="The location of the delivery installation, usually a town or city, and is only required if the area is different from the municipality. Area to which mail delivery service is provided from any postal facility or service such as an individual letter carrier, rural route, or postal route."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationArea"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationArea.partType">
+      <path value="AD.deliveryInstallationArea.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationArea.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINSTA"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationQualifier">
       <path value="AD.deliveryInstallationQualifier"/>
+      <definition value="A number, letter or name identifying a delivery installation. E.g., for Station A, the delivery installation qualifier would be 'A'."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationQualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationQualifier.partType">
+      <path value="AD.deliveryInstallationQualifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationQualifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DINSTQ"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryMode">
       <path value="AD.deliveryMode"/>
+      <definition value="Indicates the type of service offered, method of delivery. For example: post office box, rural route, general delivery, etc."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryMode"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryMode.partType">
+      <path value="AD.deliveryMode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryMode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DMOD"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.deliveryModeIdentifier">
       <path value="AD.deliveryModeIdentifier"/>
+      <definition value="Represents the routing information such as a letter carrier route number. It is the identifying number of the designator (the box number or rural route number)."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.deliveryModeIdentifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryModeIdentifier.partType">
+      <path value="AD.deliveryModeIdentifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryModeIdentifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DMODID"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.buildingNumberSuffix">
       <path value="AD.buildingNumberSuffix"/>
+      <definition value="Any alphabetic character, fraction or other text that may appear after the numeric portion of a building number"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.buildingNumberSuffix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.buildingNumberSuffix.partType">
+      <path value="AD.buildingNumberSuffix.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.buildingNumberSuffix.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="BNS"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.postBox">
       <path value="AD.postBox"/>
+      <definition value="A numbered box located in a post station."/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.postBox"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="AD.postBox.partType">
+      <path value="AD.postBox.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postBox.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="POB"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="AD.precinct">
       <path value="AD.precinct"/>
+      <definition value="A subsection of a municipality"/>
       <min value="0"/>
       <max value="*"/>
+      <base>
+        <path value="AD.precinct"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.precinct.partType">
+      <path value="AD.precinct.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.precinct.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="PRE"/>
+      <type>
+        <code value="code"/>
       </type>
     </element>
     <element id="AD.other">
       <path value="AD.other"/>
       <representation value="xmlText"/>
+      <definition value="Textual representation of (part of) the address"/>
       <min value="0"/>
       <max value="1"/>
+      <base>
+        <path value="AD.other"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
       <type>
         <code value="string"/>
       </type>

--- a/resources/ANY.xml
+++ b/resources/ANY.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="ANY">
       <path value="ANY"/>
-      <min value="1"/>
+      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -52,7 +52,7 @@
   <differential>
     <element id="ANY">
       <path value="ANY"/>
-      <min value="1"/>
+      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">

--- a/resources/BL.xml
+++ b/resources/BL.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="BL">
       <path value="BL"/>
-      <min value="1"/>
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -51,6 +51,7 @@
     <element id="BL.value">
       <path value="BL.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -66,12 +67,13 @@
   <differential>
     <element id="BL">
       <path value="BL"/>
-      <min value="1"/>
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="BL.value">
       <path value="BL.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/resources/CD.xml
+++ b/resources/CD.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CD">
       <path value="CD"/>
-      <min value="1"/>
+      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -173,6 +173,24 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
       </type>
     </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CD.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="CD.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
     <element id="CD.valueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -195,7 +213,7 @@
   <differential>
     <element id="CD">
       <path value="CD"/>
-      <min value="1"/>
+      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="CD.code">
@@ -281,6 +299,24 @@
       <max value="*"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CD.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSet"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CD.valueSetVersion">

--- a/resources/CE.xml
+++ b/resources/CE.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CE">
       <path value="CE"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -163,7 +163,7 @@
       <label value="Qualifier"/>
       <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.qualifier"/>
         <min value="0"/>
@@ -171,6 +171,24 @@
       </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CE.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="CD.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CD.valueSetVersion">
@@ -195,7 +213,7 @@
   <differential>
     <element id="CE">
       <path value="CE"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="CE.code">
@@ -264,6 +282,38 @@
       <max value="*"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
+    <element id="CE.qualifier">
+      <path value="CE.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CE.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CE.valueSet"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSet"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CE.valueSetVersion">

--- a/resources/CO.xml
+++ b/resources/CO.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CO">
       <path value="CO"/>
-      <min value="1"/>
+      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -148,7 +148,7 @@
       <label value="Translation"/>
       <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.translation"/>
         <min value="0"/>
@@ -163,7 +163,7 @@
       <label value="Qualifier"/>
       <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.qualifier"/>
         <min value="0"/>
@@ -171,6 +171,24 @@
       </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CO.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="CD.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CD.valueSetVersion">
@@ -195,7 +213,7 @@
   <differential>
     <element id="CO">
       <path value="CO"/>
-      <min value="1"/>
+      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="CO.code">
@@ -255,6 +273,47 @@
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CO.translation">
+      <path value="CO.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
+    <element id="CO.qualifier">
+      <path value="CO.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CO.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CO.valueSet"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSet"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CO.valueSetVersion">

--- a/resources/CR.xml
+++ b/resources/CR.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CR">
       <path value="CR"/>
-      <min value="1"/>
+      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -98,7 +98,7 @@
   <differential>
     <element id="CR">
       <path value="CR"/>
-      <min value="1"/>
+      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="CR.name">

--- a/resources/CS.xml
+++ b/resources/CS.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CS">
       <path value="CS"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -74,7 +74,7 @@
       <base>
         <path value="CD.codeSystem"/>
         <min value="0"/>
-        <max value="1"/>
+        <max value="0"/>
       </base>
       <type>
         <code value="string"/>
@@ -90,7 +90,7 @@
       <base>
         <path value="CD.codeSystemName"/>
         <min value="0"/>
-        <max value="1"/>
+        <max value="0"/>
       </base>
       <type>
         <code value="string"/>
@@ -106,7 +106,7 @@
       <base>
         <path value="CD.codeSystemVersion"/>
         <min value="0"/>
-        <max value="1"/>
+        <max value="0"/>
       </base>
       <type>
         <code value="string"/>
@@ -118,7 +118,7 @@
       <label value="Display Name"/>
       <definition value="A name or title for the code, under which the sending system shows the code value to its users."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="0"/>
       <base>
         <path value="CD.displayName"/>
         <min value="0"/>
@@ -133,7 +133,7 @@
       <label value="Original Text"/>
       <definition value="The text or phrase used as the basis for the coding."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="0"/>
       <base>
         <path value="CD.originalText"/>
         <min value="0"/>
@@ -148,7 +148,7 @@
       <label value="Translation"/>
       <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.translation"/>
         <min value="0"/>
@@ -163,7 +163,7 @@
       <label value="Qualifier"/>
       <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.qualifier"/>
         <min value="0"/>
@@ -171,6 +171,24 @@
       </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CS.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="CD.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CD.valueSetVersion">
@@ -191,34 +209,124 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CS.value">
-      <path value="CS.value"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CS.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
   </snapshot>
   <differential>
     <element id="CS">
       <path value="CS"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
       <max value="*"/>
     </element>
-    <element id="CS.value">
-      <path value="CS.value"/>
+    <element id="CS.code">
+      <path value="CS.code"/>
       <representation value="xmlAttr"/>
+      <label value="Code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="code"/>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.codeSystem">
+      <path value="CS.codeSystem"/>
+      <representation value="xmlAttr"/>
+      <label value="Code System"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.codeSystemName">
+      <path value="CS.codeSystemName"/>
+      <representation value="xmlAttr"/>
+      <label value="Code System Name"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.codeSystemVersion">
+      <path value="CS.codeSystemVersion"/>
+      <representation value="xmlAttr"/>
+      <label value="Code System Version"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.displayName">
+      <path value="CS.displayName"/>
+      <representation value="xmlAttr"/>
+      <label value="Display Name"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.originalText">
+      <path value="CS.originalText"/>
+      <label value="Original Text"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CS.translation">
+      <path value="CS.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
+    <element id="CS.qualifier">
+      <path value="CS.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CS.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CS.valueSet"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSet"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.valueSetVersion">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CS.valueSetVersion"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
       </type>
     </element>
   </differential>

--- a/resources/CV.xml
+++ b/resources/CV.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="CV">
       <path value="CV"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -148,7 +148,7 @@
       <label value="Translation"/>
       <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.translation"/>
         <min value="0"/>
@@ -163,7 +163,7 @@
       <label value="Qualifier"/>
       <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="0"/>
       <base>
         <path value="CD.qualifier"/>
         <min value="0"/>
@@ -171,6 +171,24 @@
       </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CV.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="CD.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CD.valueSetVersion">
@@ -195,7 +213,7 @@
   <differential>
     <element id="CV">
       <path value="CV"/>
-      <min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="CV.code">
@@ -255,6 +273,47 @@
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CV.translation">
+      <path value="CV.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
+    <element id="CV.qualifier">
+      <path value="CV.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CV.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="CV.valueSet"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSet"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="CV.valueSetVersion">

--- a/resources/ED.xml
+++ b/resources/ED.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="ED">
       <path value="ED"/>
-      <min value="1"/>
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -51,6 +51,7 @@
     <element id="ED.representation">
       <path value="ED.representation"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -60,34 +61,6 @@
       </base>
       <type>
         <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.text">
-      <path value="ED.text"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.text"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="ED.data">
-      <path value="ED.data"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.data"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="base64Binary"/>
       </type>
     </element>
     <element id="ED.mediaType">
@@ -158,21 +131,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
       </binding>
     </element>
-    <element id="ED.reference">
-      <path value="ED.reference"/>
-      <label value="Reference"/>
-      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.reference"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
-      </type>
-    </element>
     <element id="ED.integrityCheck">
       <path value="ED.integrityCheck"/>
       <representation value="xmlAttr"/>
@@ -209,6 +167,39 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
+    <element id="ED.data">
+      <path value="ED.data"/>
+      <representation value="xmlText"/>
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.)"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.data"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+      <type>
+        <code value="base64Binary"/>
+      </type>
+    </element>
+    <element id="ED.reference">
+      <path value="ED.reference"/>
+      <label value="Reference"/>
+      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.reference"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
+      </type>
+    </element>
     <element id="ED.thumbnail">
       <path value="ED.thumbnail"/>
       <label value="Thumbnail"/>
@@ -228,7 +219,7 @@
   <differential>
     <element id="ED">
       <path value="ED"/>
-      <min value="1"/>
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ED.representation">
@@ -238,24 +229,6 @@
       <max value="1"/>
       <type>
         <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.text">
-      <path value="ED.text"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="ED.data">
-      <path value="ED.data"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="base64Binary"/>
       </type>
     </element>
     <element id="ED.mediaType">
@@ -306,16 +279,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
       </binding>
     </element>
-    <element id="ED.reference">
-      <path value="ED.reference"/>
-      <label value="Reference"/>
-      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
-      </type>
-    </element>
     <element id="ED.integrityCheck">
       <path value="ED.integrityCheck"/>
       <representation value="xmlAttr"/>
@@ -341,6 +304,29 @@
         <strength value="required"/>
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
+    </element>
+    <element id="ED.data">
+      <path value="ED.data"/>
+      <representation value="xmlText"/>
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.)"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+      <type>
+        <code value="base64Binary"/>
+      </type>
+    </element>
+    <element id="ED.reference">
+      <path value="ED.reference"/>
+      <label value="Reference"/>
+      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
+      </type>
     </element>
     <element id="ED.thumbnail">
       <path value="ED.thumbnail"/>

--- a/resources/EIVL_TS.xml
+++ b/resources/EIVL_TS.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="EIVL_TS">
       <path value="EIVL_TS"/>
-      <min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -54,6 +54,7 @@
       </extension>
       <path value="EIVL_TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -68,6 +69,7 @@
     <element id="TS.inclusive">
       <path value="EIVL_TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -82,6 +84,7 @@
     <element id="SXCM_TS.operator">
       <path value="EIVL_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -127,7 +130,7 @@
   <differential>
     <element id="EIVL_TS">
       <path value="EIVL_TS"/>
-      <min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="EIVL_TS.event">

--- a/resources/EN.xml
+++ b/resources/EN.xml
@@ -28,7 +28,7 @@
   <snapshot>
     <element id="EN">
       <path value="EN"/>
-      <min value="1"/>
+      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -53,6 +53,7 @@
     </element>
     <element id="EN.delimiter">
       <path value="EN.delimiter"/>
+      <definition value="A delimiter has no meaning other than being literally printed in this name representation. A delimiter has no implicit leading and trailing white space."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -64,8 +65,41 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="EN.delimiter.partType">
+      <path value="EN.delimiter.partType"/>
+      <definition value="Specifies the type of the name part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.delimiter.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="DEL"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.delimiter.qualifier">
+      <path value="EN.delimiter.qualifier"/>
+      <definition value="Specifies the one or more subcategories of the name part in addition to the main name part type."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.delimiter.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
     <element id="EN.family">
       <path value="EN.family"/>
+      <definition value="Family name, this is the name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -77,8 +111,41 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="EN.family.partType">
+      <path value="EN.family.partType"/>
+      <definition value="Specifies the type of the name part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.family.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="FAM"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.family.qualifier">
+      <path value="EN.family.qualifier"/>
+      <definition value="Specifies the one or more subcategories of the name part in addition to the main name part type."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.family.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
     <element id="EN.given">
       <path value="EN.given"/>
+      <definition value="Given name (don't call it &quot;first name&quot; since this given names do not always come first)"/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -90,8 +157,41 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="EN.given.partType">
+      <path value="EN.given.partType"/>
+      <definition value="Specifies the type of the name part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.given.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="GIV"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.given.qualifier">
+      <path value="EN.given.qualifier"/>
+      <definition value="Specifies the one or more subcategories of the name part in addition to the main name part type."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.given.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
     <element id="EN.prefix">
       <path value="EN.prefix"/>
+      <definition value="A prefix has a strong association to the immediately following name part. A prefix has no implicit trailing white space (it has implicit leading white space though). Note that prefixes can be inverted."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -103,8 +203,41 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="EN.prefix.partType">
+      <path value="EN.prefix.partType"/>
+      <definition value="Specifies the type of the name part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.prefix.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="PFX"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.prefix.qualifier">
+      <path value="EN.prefix.qualifier"/>
+      <definition value="Specifies the one or more subcategories of the name part in addition to the main name part type."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.prefix.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
     <element id="EN.suffix">
       <path value="EN.suffix"/>
+      <definition value="A suffix has a strong association to the immediately preceding name part. A prefix has no implicit leading white space (it has implicit trailing white space though). Suffices can not be inverted."/>
       <min value="0"/>
       <max value="*"/>
       <base>
@@ -116,9 +249,42 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="EN.suffix.partType">
+      <path value="EN.suffix.partType"/>
+      <definition value="Specifies the type of the name part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.suffix.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="SFX"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.suffix.qualifier">
+      <path value="EN.suffix.qualifier"/>
+      <definition value="Specifies the one or more subcategories of the name part in addition to the main name part type."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.suffix.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
     <element id="EN.other">
       <path value="EN.other"/>
       <representation value="xmlText"/>
+      <definition value="Textual representation of (part of) the name"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -165,7 +331,7 @@
   <differential>
     <element id="EN">
       <path value="EN"/>
-      <min value="1"/>
+      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="EN.delimiter">

--- a/resources/II.xml
+++ b/resources/II.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="II">
       <path value="II"/>
-      <min value="1"/>
+      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -116,7 +116,7 @@
   <differential>
     <element id="II">
       <path value="II"/>
-      <min value="1"/>
+      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="II.root">

--- a/resources/INT.xml
+++ b/resources/INT.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="INT">
       <path value="INT"/>
-      <min value="1"/>
+      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -51,6 +51,7 @@
     <element id="INT.value">
       <path value="INT.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The integer value"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -66,7 +67,7 @@
   <differential>
     <element id="INT">
       <path value="INT"/>
-      <min value="1"/>
+      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="INT.value">

--- a/resources/IVL_INT.xml
+++ b/resources/IVL_INT.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_INT">
       <path value="IVL_INT"/>
+      <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -45,6 +46,7 @@
     <element id="IVL_INT.value">
       <path value="IVL_INT.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The integer value. Possible for runtime of the interval to a single integer."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -120,6 +122,7 @@
   <differential>
     <element id="IVL_INT">
       <path value="IVL_INT"/>
+      <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/resources/IVL_PQ.xml
+++ b/resources/IVL_PQ.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_PQ">
       <path value="IVL_PQ"/>
+      <definition value="Interval of physical quantities"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/resources/IVL_TS.xml
+++ b/resources/IVL_TS.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_TS">
       <path value="IVL_TS"/>
+      <definition value="Interval of timestamps"/>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -48,6 +49,7 @@
       </extension>
       <path value="IVL_TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -62,6 +64,7 @@
     <element id="IVL_TS.inclusive">
       <path value="IVL_TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -76,6 +79,7 @@
     <element id="SXCM_TS.operator">
       <path value="IVL_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <base>

--- a/resources/MO.xml
+++ b/resources/MO.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="MO">
       <path value="MO"/>
-      <min value="1"/>
+      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -82,7 +82,7 @@
   <differential>
     <element id="MO">
       <path value="MO"/>
-      <min value="1"/>
+      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="MO.value">

--- a/resources/PIVL_TS.xml
+++ b/resources/PIVL_TS.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="PIVL_TS">
       <path value="PIVL_TS"/>
-      <min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -54,6 +54,7 @@
       </extension>
       <path value="PIVL_TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -68,6 +69,7 @@
     <element id="TS.inclusive">
       <path value="PIVL_TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -82,6 +84,7 @@
     <element id="SXCM_TS.operator">
       <path value="PIVL_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -159,7 +162,7 @@
   <differential>
     <element id="PIVL_TS">
       <path value="PIVL_TS"/>
-      <min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="PIVL_TS.phase">

--- a/resources/PQ.xml
+++ b/resources/PQ.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="PQ">
       <path value="PQ"/>
-      <min value="1"/>
+      <definition value="A dimensioned quantity expressing the result of a measurement act."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -76,8 +76,24 @@
         <min value="0"/>
         <max value="1"/>
       </base>
+      <defaultValueCode value="1"/>
       <type>
         <code value="code"/>
+      </type>
+    </element>
+    <element id="PQ.inclusive">
+      <path value="PQ.inclusive"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="PQ.inclusive"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="boolean"/>
       </type>
     </element>
     <element id="PQ.translation">
@@ -95,25 +111,11 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQR"/>
       </type>
     </element>
-    <element id="PQ.inclusive">
-      <path value="PQ.inclusive"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="PQ.inclusive"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
   </snapshot>
   <differential>
     <element id="PQ">
       <path value="PQ"/>
-      <min value="1"/>
+      <definition value="A dimensioned quantity expressing the result of a measurement act."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="PQ.value">
@@ -138,6 +140,15 @@
         <code value="code"/>
       </type>
     </element>
+    <element id="PQ.inclusive">
+      <path value="PQ.inclusive"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
     <element id="PQ.translation">
       <path value="PQ.translation"/>
       <label value="Translation"/>
@@ -146,15 +157,6 @@
       <max value="*"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQR"/>
-      </type>
-    </element>
-    <element id="PQ.inclusive">
-      <path value="PQ.inclusive"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
       </type>
     </element>
   </differential>

--- a/resources/PQR.xml
+++ b/resources/PQR.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="PQR">
       <path value="PQR"/>
-      <min value="1"/>
+      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -211,7 +211,7 @@
   <differential>
     <element id="PQR">
       <path value="PQR"/>
-      <min value="1"/>
+      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="PQR.value">

--- a/resources/QTY.xml
+++ b/resources/QTY.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="QTY">
       <path value="QTY"/>
-      <min value="1"/>
+      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -52,7 +52,7 @@
   <differential>
     <element id="QTY">
       <path value="QTY"/>
-      <min value="1"/>
+      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/><min value="1"/>
       <max value="*"/>
     </element>
   </differential>

--- a/resources/REAL.xml
+++ b/resources/REAL.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="REAL">
       <path value="REAL"/>
-      <min value="1"/>
+      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -51,6 +51,7 @@
     <element id="REAL.value">
       <path value="REAL.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The decimal value"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -66,7 +67,7 @@
   <differential>
     <element id="REAL">
       <path value="REAL"/>
-      <min value="1"/>
+      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="REAL.value">

--- a/resources/RTO_PQ_PQ.xml
+++ b/resources/RTO_PQ_PQ.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="RTO_PQ_PQ">
       <path value="RTO_PQ_PQ"/>
+      <definition value="A ratio of a physical quantity (PQ) numerator and a physical quantity (PQ) denominator."/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/resources/SC.xml
+++ b/resources/SC.xml
@@ -25,7 +25,7 @@
   <snapshot>
     <element id="SC">
       <path value="SC"/>
-      <min value="1"/>
+      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -51,6 +51,7 @@
     <element id="ST.value">
       <path value="SC.value"/>
       <representation value="xmlText"/>
+      <definition value="The string value"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -66,6 +67,7 @@
       <path value="SC.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
+      <definition value="The plain code symbol defined by the code system. For example, &quot;784.0&quot; is the code symbol of the ICD-9 code &quot;784.0&quot; for headache."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -81,6 +83,7 @@
       <path value="SC.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
+      <definition value="Specifies the code system that defines the code."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -92,10 +95,27 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="SC.codeSystemName">
+      <path value="SC.codeSystemName"/>
+      <representation value="xmlAttr"/>
+      <label value="Code System Name"/>
+      <definition value="The common name of the coding system."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="SC.codeSystemName"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
     <element id="SC.codeSystemVersion">
       <path value="SC.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
+      <definition value="If applicable, a version descriptor defined specifically for the given code system."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -111,6 +131,7 @@
       <path value="SC.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
+      <definition value="A name or title for the code, under which the sending system shows the code value to its users."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -126,7 +147,7 @@
   <differential>
     <element id="SC">
       <path value="SC"/>
-      <min value="1"/>
+      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="SC.code">
@@ -143,6 +164,16 @@
       <path value="SC.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="SC.codeSystemName">
+      <path value="SC.codeSystemName"/>
+      <representation value="xmlAttr"/>
+      <label value="Code System Name"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/resources/ST.xml
+++ b/resources/ST.xml
@@ -20,12 +20,12 @@
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="ST"/>
-  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ANY"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
   <derivation value="specialization"/>
   <snapshot>
     <element id="ST">
       <path value="ST"/>
-      <min value="1"/>
+      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/><min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -48,13 +48,135 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="ST.value">
-      <path value="ST.value"/>
-      <representation value="xmlText"/>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="ST.value"/>
+        <path value="ED.representation"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="TXT"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.mediaType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <fixedCode value="text/plain"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.charset">
+      <path value="ST.charset"/>
+      <representation value="xmlAttr"/>
+      <label value="Charset"/>
+      <definition value="For character-based encoding types, this property specifies the character set and character encoding used. The charset shall be identified by an Internet Assigned Numbers Authority (IANA) Charset Registration [] in accordance with RFC 2978 []."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.charset"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.language">
+      <path value="ST.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.language"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.compression">
+      <path value="ST.compression"/>
+      <representation value="xmlAttr"/>
+      <label value="Compression"/>
+      <definition value="Indicates whether the raw byte data is compressed, and what compression algorithm was used."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="ED.compression"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
+      </binding>
+    </element>
+    <element id="ST.integrityCheck">
+      <path value="ST.integrityCheck"/>
+      <representation value="xmlAttr"/>
+      <label value="Integrity Check"/>
+      <definition value="The integrity check is a short binary value representing a cryptographically strong checksum that is calculated over the binary data. The purpose of this property, when communicated with a reference is for anyone to validate later whether the reference still resolved to the same data that the reference resolved to when the encapsulated data value with reference was created."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="ED.integrityCheck"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="base64Binary"/>
+      </type>
+    </element>
+    <element id="ST.integrityCheckAlgorithm">
+      <path value="ST.integrityCheckAlgorithm"/>
+      <representation value="xmlAttr"/>
+      <label value="Integrity Check Algorithm"/>
+      <definition value="Specifies the algorithm used to compute the integrityCheck value. The cryptographically strong checksum algorithm Secure Hash Algorithm-1 (SHA-1) is currently the industry standard. It has superseded the MD5 algorithm only a couple of years ago, when certain flaws in the security of MD5 were discovered. Currently the SHA-1 hash algorithm is the default choice for the integrity check algorithm. Note that SHA-256 is also entering widespread usage."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="ED.integrityCheckAlgorithm"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
+      </binding>
+    </element>
+    <element id="ST.data">
+      <path value="ST.data"/>
+      <representation value="xmlText"/>
+      <definition value="The string value"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.data"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -62,20 +184,156 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="ST.reference">
+      <path value="ST.reference"/>
+      <label value="Reference"/>
+      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="ED.reference"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
+      </type>
+    </element>
+    <element id="ST.thumbnail">
+      <path value="ST.thumbnail"/>
+      <label value="Thumbnail"/>
+      <definition value="An abbreviated rendition of the full data. A thumbnail requires significantly fewer resources than the full data, while still maintaining some distinctive similarity with the full data. A thumbnail is typically used with by-reference encapsulated data. It allows a user to select data more efficiently before actually downloading through the reference."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="ED.thumbnail"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="ST">
       <path value="ST"/>
-      <min value="1"/>
+      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/><min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ST.value">
-      <path value="ST.value"/>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <fixedCode value="TXT"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <fixedCode value="text/plain"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.charset">
+      <path value="ST.charset"/>
+      <representation value="xmlAttr"/>
+      <label value="Charset"/>
+      <definition value="For character-based encoding types, this property specifies the character set and character encoding used. The charset shall be identified by an Internet Assigned Numbers Authority (IANA) Charset Registration [] in accordance with RFC 2978 []."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.language">
+      <path value="ST.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.compression">
+      <path value="ST.compression"/>
+      <representation value="xmlAttr"/>
+      <label value="Compression"/>
+      <definition value="Indicates whether the raw byte data is compressed, and what compression algorithm was used."/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
+      </binding>
+    </element>
+    <element id="ST.integrityCheck">
+      <path value="ST.integrityCheck"/>
+      <representation value="xmlAttr"/>
+      <label value="Integrity Check"/>
+      <definition value="The integrity check is a short binary value representing a cryptographically strong checksum that is calculated over the binary data. The purpose of this property, when communicated with a reference is for anyone to validate later whether the reference still resolved to the same data that the reference resolved to when the encapsulated data value with reference was created."/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="base64Binary"/>
+      </type>
+    </element>
+    <element id="ST.integrityCheckAlgorithm">
+      <path value="ST.integrityCheckAlgorithm"/>
+      <representation value="xmlAttr"/>
+      <label value="Integrity Check Algorithm"/>
+      <definition value="Specifies the algorithm used to compute the integrityCheck value. The cryptographically strong checksum algorithm Secure Hash Algorithm-1 (SHA-1) is currently the industry standard. It has superseded the MD5 algorithm only a couple of years ago, when certain flaws in the security of MD5 were discovered. Currently the SHA-1 hash algorithm is the default choice for the integrity check algorithm. Note that SHA-256 is also entering widespread usage."/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
+      </binding>
+    </element>
+    <element id="ST.data">
+      <path value="ST.data"/>
       <representation value="xmlText"/>
+      <definition value="The string value"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="ST.reference">
+      <path value="ST.reference"/>
+      <label value="Reference"/>
+      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
+      </type>
+    </element>
+    <element id="ST.thumbnail">
+      <path value="ST.thumbnail"/>
+      <label value="Thumbnail"/>
+      <definition value="An abbreviated rendition of the full data. A thumbnail requires significantly fewer resources than the full data, while still maintaining some distinctive similarity with the full data. A thumbnail is typically used with by-reference encapsulated data. It allows a user to select data more efficiently before actually downloading through the reference."/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
       </type>
     </element>
   </differential>

--- a/resources/SXCM_TS.xml
+++ b/resources/SXCM_TS.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="SXCM_TS">
       <path value="SXCM_TS"/>
+      <definition value="Speciolization for timing specification of generic type extension for the base data type of a set, representing a component of a general set over a discrete or continuous value domain. Its use is mainly for continuous value domains. Discrete (enumerable) set components are the individual elements of the base data type."/>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -48,6 +49,7 @@
       </extension>
       <path value="SXCM_TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -62,6 +64,7 @@
     <element id="TS.inclusive">
       <path value="SXCM_TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -76,6 +79,7 @@
     <element id="SXCM_TS.operator">
       <path value="SXCM_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -97,6 +101,7 @@
     <element id="SXCM_TS.operator">
       <path value="SXCM_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/resources/SXPR_TS.xml
+++ b/resources/SXPR_TS.xml
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="SXPR_TS">
       <path value="SXPR_TS"/>
+      <definition value="A set-component that is itself made up of set-components that are evaluated as one value."></definition>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -48,6 +49,7 @@
       </extension>
       <path value="SXPR_TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -62,6 +64,7 @@
     <element id="TS.inclusive">
       <path value="SXPR_TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -76,6 +79,7 @@
     <element id="SXCM_TS.operator">
       <path value="SXPR_TS.operator"/>
       <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -90,6 +94,7 @@
     <element id="SXPR_TS.comp">
       <path value="SXPR_TS.comp"/>
       <representation value="typeAttr"/>
+      <definition value="comp is represented by the XML element comp which, if present, must be a valid SXCM"/>
       <min value="1"/>
       <max value="*"/>
       <base>

--- a/resources/TEL.xml
+++ b/resources/TEL.xml
@@ -25,6 +25,7 @@
   <snapshot>
     <element id="TEL">
       <path value="TEL"/>
+      <definition value="A telephone number (voice or fax), e-mail address, or other locator for a resource (information or service) mediated by telecommunication equipment."/>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -51,6 +52,7 @@
     <element id="TEL.value">
       <path value="TEL.value"/>
       <representation value="xmlAttr"/>
+      <definition value="The telecommunications address specified as a URL"/>
       <min value="0"/>
       <max value="1"/>
       <base>

--- a/resources/TS.xml
+++ b/resources/TS.xml
@@ -28,6 +28,7 @@
         <valueCode value="YYYYMMDDHHMMSS.UUUU[+|-ZZzz]"/>
       </extension>
       <path value="TS"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."></definition>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -57,6 +58,7 @@
       </extension>
       <path value="TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -71,6 +73,7 @@
     <element id="TS.inclusive">
       <path value="TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -89,6 +92,7 @@
         <valueCode value="YYYYMMDDHHMMSS.UUUU[+|-ZZzz]"/>
       </extension>
       <path value="TS"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."></definition>
       <min value="1"/>
       <max value="*"/>
     </element>
@@ -98,6 +102,7 @@
       </extension>
       <path value="TS.value"/>
       <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -107,6 +112,7 @@
     <element id="TS.inclusive">
       <path value="TS.inclusive"/>
       <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
For the better part this is about adding the missing element definitions starting with the datatypes. I think this is necessary because without those every dependent IG will need to add these for datatypes they use or accept the same 

Each element definition in a snapshot must have a formal definition and cardinalities [element.all(definition.exists() and min.exists() and max.exists())]

I also fixed a large number of other datatype issues. Missing attributes, elements etc.