### PR TITLE
Open/save with Forge STU3 Montreal 2019 Edition

### DIFF
--- a/resources/AD.xml
+++ b/resources/AD.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="AD"/>
   <text>
@@ -28,11 +28,12 @@
   <snapshot>
     <element id="AD">
       <path value="AD"/>
+      <short value="Address" />
       <definition value="Mailing and home or office addresses. A sequence of address parts, such as street or post office Box, city, postal code, country, etc."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="AD.nullFlavor">
       <path value="AD.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -52,829 +53,20 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="AD.delimiter">
-      <path value="AD.delimiter"/>
-      <definition value="Delimiters are printed without framing white space. If no value component is provided, the delimiter appears as a line break."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.delimiter"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.delimiter.partType">
-      <path value="AD.delimiter.partType"/>
+    <element id="AD.isNotOrdered">
+      <path value="AD.isNotOrdered"/>
       <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
+      <label value="Is Not Ordered"/>
+      <definition value="A boolean value specifying whether the order of the address parts is known or not. While the address parts are always a Sequence, the order in which they are presented may or may not be known. Where this matters, the isNotOrdered property can be used to convey this information."/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="AD.delimiter.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DEL"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.country">
-      <path value="AD.country"/>
-      <definition value="Country"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.country"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.country.partType">
-      <path value="AD.country.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.country.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="CNT"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.state">
-      <path value="AD.state"/>
-      <definition value="A sub-unit of a country with limited sovereignty in a federally organized country."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.state"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.state.partType">
-      <path value="AD.state.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.state.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="STA"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.county">
-      <path value="AD.county"/>
-      <definition value="A sub-unit of a state or province. (49 of the United States of America use the term &quot;county;&quot; Louisiana uses the term &quot;parish&quot;.)"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.county"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.county.partType">
-      <path value="AD.county.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.county.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="CPA"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.city">
-      <path value="AD.city"/>
-      <definition value="The name of the city, town, village, or other community or delivery center"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.city"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.city.partType">
-      <path value="AD.city.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.city.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="CTY"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.postalCode">
-      <path value="AD.postalCode"/>
-      <definition value="A postal code designating a region defined by the postal service."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.postalCode"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.postalCode.partType">
-      <path value="AD.postalCode.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.postalCode.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="ZIP"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.streetAddressLine">
-      <path value="AD.streetAddressLine"/>
-      <definition value="Street address line"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.streetAddressLine"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.streetAddressLine.partType">
-      <path value="AD.streetAddressLine.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.streetAddressLine.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="SAL"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.houseNumber">
-      <path value="AD.houseNumber"/>
-      <definition value="The number of a building, house or lot alongside the street. Also known as &quot;primary street number&quot;. This does not number the street but rather the building."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.houseNumber"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.houseNumber.partType">
-      <path value="AD.houseNumber.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.houseNumber.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="BNR"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.houseNumberNumeric">
-      <path value="AD.houseNumberNumeric"/>
-      <definition value="The numeric portion of a building number"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.houseNumberNumeric"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.houseNumberNumeric.partType">
-      <path value="AD.houseNumberNumeric.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.houseNumberNumeric.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="BNN"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.direction">
-      <path value="AD.direction"/>
-      <definition value="Direction (e.g., N, S, W, E)"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.direction"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.direction.partType">
-      <path value="AD.direction.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.direction.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DIR"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.streetName">
-      <path value="AD.streetName"/>
-      <definition value="Name of a roadway or artery recognized by a municipality (including street type and direction)"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.streetName"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.streetName.partType">
-      <path value="AD.streetName.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.streetName.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="STR"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.streetNameBase">
-      <path value="AD.streetNameBase"/>
-      <definition value="The base name of a roadway or artery recognized by a municipality (excluding street type and direction)"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.streetNameBase"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.streetNameBase.partType">
-      <path value="AD.streetNameBase.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.streetNameBase.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="STB"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.streetNameType">
-      <path value="AD.streetNameType"/>
-      <definition value="The designation given to the street. (e.g. Street, Avenue, Crescent, etc.)"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.streetNameType"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.streetNameType.partType">
-      <path value="AD.streetNameType.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.streetNameType.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="STTYP"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.additionalLocator">
-      <path value="AD.additionalLocator"/>
-      <definition value="This can be a unit designator, such as apartment number, suite number, or floor. There may be several unit designators in an address (e.g., &quot;3rd floor, Appt. 342&quot;). This can also be a designator pointing away from the location, rather than specifying a smaller location within some larger one (e.g., Dutch &quot;t.o.&quot; means &quot;opposite to&quot; for house boats located across the street facing houses)."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.additionalLocator"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.additionalLocator.partType">
-      <path value="AD.additionalLocator.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.additionalLocator.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="ADL"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.unitID">
-      <path value="AD.unitID"/>
-      <definition value="The number or name of a specific unit contained within a building or complex, as assigned by that building or complex."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.unitID"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.unitID.partType">
-      <path value="AD.unitID.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.unitID.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="UNID"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.unitType">
-      <path value="AD.unitType"/>
-      <definition value="Indicates the type of specific unit contained within a building or complex. E.g. Appartment, Floor"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.unitType"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.unitType.partType">
-      <path value="AD.unitType.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.unitType.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="UNIT"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.careOf">
-      <path value="AD.careOf"/>
-      <definition value="The name of the party who will take receipt at the specified address, and will take on responsibility for ensuring delivery to the target recipient"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.careOf"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.careOf.partType">
-      <path value="AD.careOf.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.careOf.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="CAR"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.censusTract">
-      <path value="AD.censusTract"/>
-      <definition value="A geographic sub-unit delineated for demographic purposes."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.censusTract"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.censusTract.partType">
-      <path value="AD.censusTract.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.censusTract.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="CEN"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryAddressLine">
-      <path value="AD.deliveryAddressLine"/>
-      <definition value="A delivery address line is frequently used instead of breaking out delivery mode, delivery installation, etc. An address generally has only a delivery address line or a street address line, but not both."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryAddressLine"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryAddressLine.partType">
-      <path value="AD.deliveryAddressLine.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryAddressLine.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DAL"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationType">
-      <path value="AD.deliveryInstallationType"/>
-      <definition value="Indicates the type of delivery installation (the facility to which the mail will be delivered prior to final shipping via the delivery mode.) Example: post office, letter carrier depot, community mail center, station, etc."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryInstallationType"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationType.partType">
-      <path value="AD.deliveryInstallationType.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryInstallationType.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DINST"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationArea">
-      <path value="AD.deliveryInstallationArea"/>
-      <definition value="The location of the delivery installation, usually a town or city, and is only required if the area is different from the municipality. Area to which mail delivery service is provided from any postal facility or service such as an individual letter carrier, rural route, or postal route."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryInstallationArea"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationArea.partType">
-      <path value="AD.deliveryInstallationArea.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryInstallationArea.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DINSTA"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationQualifier">
-      <path value="AD.deliveryInstallationQualifier"/>
-      <definition value="A number, letter or name identifying a delivery installation. E.g., for Station A, the delivery installation qualifier would be 'A'."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryInstallationQualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryInstallationQualifier.partType">
-      <path value="AD.deliveryInstallationQualifier.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryInstallationQualifier.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DINSTQ"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryMode">
-      <path value="AD.deliveryMode"/>
-      <definition value="Indicates the type of service offered, method of delivery. For example: post office box, rural route, general delivery, etc."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryMode"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryMode.partType">
-      <path value="AD.deliveryMode.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryMode.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DMOD"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.deliveryModeIdentifier">
-      <path value="AD.deliveryModeIdentifier"/>
-      <definition value="Represents the routing information such as a letter carrier route number. It is the identifying number of the designator (the box number or rural route number)."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.deliveryModeIdentifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.deliveryModeIdentifier.partType">
-      <path value="AD.deliveryModeIdentifier.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.deliveryModeIdentifier.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="DMODID"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.buildingNumberSuffix">
-      <path value="AD.buildingNumberSuffix"/>
-      <definition value="Any alphabetic character, fraction or other text that may appear after the numeric portion of a building number"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.buildingNumberSuffix"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.buildingNumberSuffix.partType">
-      <path value="AD.buildingNumberSuffix.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.buildingNumberSuffix.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="BNS"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.postBox">
-      <path value="AD.postBox"/>
-      <definition value="A numbered box located in a post station."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.postBox"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.postBox.partType">
-      <path value="AD.postBox.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.postBox.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="POB"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.precinct">
-      <path value="AD.precinct"/>
-      <definition value="A subsection of a municipality"/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.precinct"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="AD.precinct.partType">
-      <path value="AD.precinct.partType"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the type of the address part"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.precinct.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="PRE"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="AD.other">
-      <path value="AD.other"/>
-      <representation value="xmlText"/>
-      <definition value="Textual representation of (part of) the address"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.other"/>
+        <path value="AD.isNotOrdered"/>
         <min value="0"/>
         <max value="1"/>
       </base>
       <type>
-        <code value="string"/>
+        <code value="boolean"/>
       </type>
     </element>
     <element id="AD.use">
@@ -893,58 +85,6 @@
         <code value="code"/>
       </type>
     </element>
-    <element id="AD.useablePeriod">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="SXPR_TS"/>
-      </extension>
-      <path value="AD.useablePeriod"/>
-      <representation value="typeAttr"/>
-      <label value="Useable Period"/>
-      <definition value="A General Timing Specification (GTS) specifying the periods of time during which the address can be used. This is used to specify different addresses for different times of the week or year."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="AD.useablePeriod"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
-      </type>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
-      </type>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
-      </type>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
-      </type>
-    </element>
-    <element id="AD.isNotOrdered">
-      <path value="AD.isNotOrdered"/>
-      <representation value="xmlAttr"/>
-      <label value="Is Not Ordered"/>
-      <definition value="A boolean value specifying whether the order of the address parts is known or not. While the address parts are always a Sequence, the order in which they are presented may or may not be known. Where this matters, the isNotOrdered property can be used to convey this information."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="AD.isNotOrdered"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-  </snapshot>
-  <differential>
-    <element id="AD">
-      <path value="AD"/>
-      <definition value="Mailing and home or office addresses. A sequence of address parts, such as street or post office Box, city, postal code, country, etc."/>
-      <min value="1"/>
-      <max value="*"/>
-    </element>
     <element id="AD.delimiter">
       <path value="AD.delimiter"/>
       <definition value="Delimiters are printed without framing white space. If no value component is provided, the delimiter appears as a line break."/>
@@ -970,10 +110,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DEL"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DEL"/>
     </element>
     <element id="AD.country">
       <path value="AD.country"/>
@@ -1000,10 +140,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="CNT"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="CNT"/>
     </element>
     <element id="AD.state">
       <path value="AD.state"/>
@@ -1030,10 +170,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="STA"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="STA"/>
     </element>
     <element id="AD.county">
       <path value="AD.county"/>
@@ -1060,10 +200,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="CPA"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="CPA"/>
     </element>
     <element id="AD.city">
       <path value="AD.city"/>
@@ -1090,10 +230,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="CTY"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="CTY"/>
     </element>
     <element id="AD.postalCode">
       <path value="AD.postalCode"/>
@@ -1120,10 +260,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="ZIP"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="ZIP"/>
     </element>
     <element id="AD.streetAddressLine">
       <path value="AD.streetAddressLine"/>
@@ -1150,10 +290,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="SAL"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="SAL"/>
     </element>
     <element id="AD.houseNumber">
       <path value="AD.houseNumber"/>
@@ -1180,10 +320,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="BNR"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="BNR"/>
     </element>
     <element id="AD.houseNumberNumeric">
       <path value="AD.houseNumberNumeric"/>
@@ -1210,10 +350,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="BNN"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="BNN"/>
     </element>
     <element id="AD.direction">
       <path value="AD.direction"/>
@@ -1240,10 +380,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DIR"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DIR"/>
     </element>
     <element id="AD.streetName">
       <path value="AD.streetName"/>
@@ -1270,10 +410,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="STR"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="STR"/>
     </element>
     <element id="AD.streetNameBase">
       <path value="AD.streetNameBase"/>
@@ -1300,10 +440,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="STB"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="STB"/>
     </element>
     <element id="AD.streetNameType">
       <path value="AD.streetNameType"/>
@@ -1330,10 +470,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="STTYP"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="STTYP"/>
     </element>
     <element id="AD.additionalLocator">
       <path value="AD.additionalLocator"/>
@@ -1360,10 +500,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="ADL"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="ADL"/>
     </element>
     <element id="AD.unitID">
       <path value="AD.unitID"/>
@@ -1390,10 +530,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="UNID"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="UNID"/>
     </element>
     <element id="AD.unitType">
       <path value="AD.unitType"/>
@@ -1420,10 +560,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="UNIT"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="UNIT"/>
     </element>
     <element id="AD.careOf">
       <path value="AD.careOf"/>
@@ -1450,10 +590,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="CAR"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="CAR"/>
     </element>
     <element id="AD.censusTract">
       <path value="AD.censusTract"/>
@@ -1480,10 +620,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="CEN"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="CEN"/>
     </element>
     <element id="AD.deliveryAddressLine">
       <path value="AD.deliveryAddressLine"/>
@@ -1510,10 +650,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DAL"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DAL"/>
     </element>
     <element id="AD.deliveryInstallationType">
       <path value="AD.deliveryInstallationType"/>
@@ -1540,10 +680,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DINST"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DINST"/>
     </element>
     <element id="AD.deliveryInstallationArea">
       <path value="AD.deliveryInstallationArea"/>
@@ -1570,10 +710,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DINSTA"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DINSTA"/>
     </element>
     <element id="AD.deliveryInstallationQualifier">
       <path value="AD.deliveryInstallationQualifier"/>
@@ -1600,10 +740,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DINSTQ"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DINSTQ"/>
     </element>
     <element id="AD.deliveryMode">
       <path value="AD.deliveryMode"/>
@@ -1630,10 +770,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DMOD"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DMOD"/>
     </element>
     <element id="AD.deliveryModeIdentifier">
       <path value="AD.deliveryModeIdentifier"/>
@@ -1660,10 +800,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DMODID"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DMODID"/>
     </element>
     <element id="AD.buildingNumberSuffix">
       <path value="AD.buildingNumberSuffix"/>
@@ -1690,10 +830,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="BNS"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="BNS"/>
     </element>
     <element id="AD.postBox">
       <path value="AD.postBox"/>
@@ -1720,10 +860,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="POB"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="POB"/>
     </element>
     <element id="AD.precinct">
       <path value="AD.precinct"/>
@@ -1750,10 +890,10 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="PRE"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="PRE"/>
     </element>
     <element id="AD.other">
       <path value="AD.other"/>
@@ -1770,6 +910,78 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="AD.useablePeriod[x]">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
+        <valueString value="SXPR_TS"/>
+      </extension>
+      <path value="AD.useablePeriod[x]"/>
+      <representation value="typeAttr"/>
+      <label value="Useable Period"/>
+      <definition value="A General Timing Specification (GTS) specifying the periods of time during which the address can be used. This is used to specify different addresses for different times of the week or year."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.useablePeriod[x]"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
+      </type>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
+      </type>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
+      </type>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
+      </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="AD">
+      <path value="AD"/>
+      <definition value="Mailing and home or office addresses. A sequence of address parts, such as street or post office Box, city, postal code, country, etc."/>
+      <min value="1"/>
+      <max value="*"/>
+      <base>
+        <path value="ANY"/>
+        <min value="1"/>
+        <max value="*"/>
+      </base>
+    </element>
+    <element id="AD.nullFlavor">
+      <path value="AD.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="AD.isNotOrdered">
+      <path value="AD.isNotOrdered"/>
+      <representation value="xmlAttr"/>
+      <label value="Is Not Ordered"/>
+      <definition value="A boolean value specifying whether the order of the address parts is known or not. While the address parts are always a Sequence, the order in which they are presented may or may not be known. Where this matters, the isNotOrdered property can be used to convey this information."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
     <element id="AD.use">
       <path value="AD.use"/>
       <representation value="xmlAttr"/>
@@ -1781,11 +993,836 @@
         <code value="code"/>
       </type>
     </element>
+    <element id="AD.delimiter">
+      <path value="AD.delimiter"/>
+      <definition value="Delimiters are printed without framing white space. If no value component is provided, the delimiter appears as a line break."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.delimiter"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.delimiter.partType">
+      <path value="AD.delimiter.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.delimiter.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DEL"/>
+    </element>
+    <element id="AD.country">
+      <path value="AD.country"/>
+      <definition value="Country"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.country"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.country.partType">
+      <path value="AD.country.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.country.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="CNT"/>
+    </element>
+    <element id="AD.state">
+      <path value="AD.state"/>
+      <definition value="A sub-unit of a country with limited sovereignty in a federally organized country."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.state"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.state.partType">
+      <path value="AD.state.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.state.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="STA"/>
+    </element>
+    <element id="AD.county">
+      <path value="AD.county"/>
+      <definition value="A sub-unit of a state or province. (49 of the United States of America use the term &quot;county;&quot; Louisiana uses the term &quot;parish&quot;.)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.county"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.county.partType">
+      <path value="AD.county.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.county.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="CPA"/>
+    </element>
+    <element id="AD.city">
+      <path value="AD.city"/>
+      <definition value="The name of the city, town, village, or other community or delivery center"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.city"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.city.partType">
+      <path value="AD.city.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.city.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="CTY"/>
+    </element>
+    <element id="AD.postalCode">
+      <path value="AD.postalCode"/>
+      <definition value="A postal code designating a region defined by the postal service."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.postalCode"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.postalCode.partType">
+      <path value="AD.postalCode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postalCode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="ZIP"/>
+    </element>
+    <element id="AD.streetAddressLine">
+      <path value="AD.streetAddressLine"/>
+      <definition value="Street address line"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.streetAddressLine"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetAddressLine.partType">
+      <path value="AD.streetAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="SAL"/>
+    </element>
+    <element id="AD.houseNumber">
+      <path value="AD.houseNumber"/>
+      <definition value="The number of a building, house or lot alongside the street. Also known as &quot;primary street number&quot;. This does not number the street but rather the building."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.houseNumber"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.houseNumber.partType">
+      <path value="AD.houseNumber.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumber.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="BNR"/>
+    </element>
+    <element id="AD.houseNumberNumeric">
+      <path value="AD.houseNumberNumeric"/>
+      <definition value="The numeric portion of a building number"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.houseNumberNumeric"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.houseNumberNumeric.partType">
+      <path value="AD.houseNumberNumeric.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.houseNumberNumeric.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="BNN"/>
+    </element>
+    <element id="AD.direction">
+      <path value="AD.direction"/>
+      <definition value="Direction (e.g., N, S, W, E)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.direction"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.direction.partType">
+      <path value="AD.direction.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.direction.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DIR"/>
+    </element>
+    <element id="AD.streetName">
+      <path value="AD.streetName"/>
+      <definition value="Name of a roadway or artery recognized by a municipality (including street type and direction)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.streetName"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetName.partType">
+      <path value="AD.streetName.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetName.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="STR"/>
+    </element>
+    <element id="AD.streetNameBase">
+      <path value="AD.streetNameBase"/>
+      <definition value="The base name of a roadway or artery recognized by a municipality (excluding street type and direction)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.streetNameBase"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetNameBase.partType">
+      <path value="AD.streetNameBase.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameBase.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="STB"/>
+    </element>
+    <element id="AD.streetNameType">
+      <path value="AD.streetNameType"/>
+      <definition value="The designation given to the street. (e.g. Street, Avenue, Crescent, etc.)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.streetNameType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.streetNameType.partType">
+      <path value="AD.streetNameType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.streetNameType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="STTYP"/>
+    </element>
+    <element id="AD.additionalLocator">
+      <path value="AD.additionalLocator"/>
+      <definition value="This can be a unit designator, such as apartment number, suite number, or floor. There may be several unit designators in an address (e.g., &quot;3rd floor, Appt. 342&quot;). This can also be a designator pointing away from the location, rather than specifying a smaller location within some larger one (e.g., Dutch &quot;t.o.&quot; means &quot;opposite to&quot; for house boats located across the street facing houses)."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.additionalLocator"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.additionalLocator.partType">
+      <path value="AD.additionalLocator.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.additionalLocator.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="ADL"/>
+    </element>
+    <element id="AD.unitID">
+      <path value="AD.unitID"/>
+      <definition value="The number or name of a specific unit contained within a building or complex, as assigned by that building or complex."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.unitID"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.unitID.partType">
+      <path value="AD.unitID.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitID.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="UNID"/>
+    </element>
+    <element id="AD.unitType">
+      <path value="AD.unitType"/>
+      <definition value="Indicates the type of specific unit contained within a building or complex. E.g. Appartment, Floor"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.unitType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.unitType.partType">
+      <path value="AD.unitType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.unitType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="UNIT"/>
+    </element>
+    <element id="AD.careOf">
+      <path value="AD.careOf"/>
+      <definition value="The name of the party who will take receipt at the specified address, and will take on responsibility for ensuring delivery to the target recipient"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.careOf"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.careOf.partType">
+      <path value="AD.careOf.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.careOf.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="CAR"/>
+    </element>
+    <element id="AD.censusTract">
+      <path value="AD.censusTract"/>
+      <definition value="A geographic sub-unit delineated for demographic purposes."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.censusTract"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.censusTract.partType">
+      <path value="AD.censusTract.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.censusTract.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="CEN"/>
+    </element>
+    <element id="AD.deliveryAddressLine">
+      <path value="AD.deliveryAddressLine"/>
+      <definition value="A delivery address line is frequently used instead of breaking out delivery mode, delivery installation, etc. An address generally has only a delivery address line or a street address line, but not both."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryAddressLine"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryAddressLine.partType">
+      <path value="AD.deliveryAddressLine.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryAddressLine.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DAL"/>
+    </element>
+    <element id="AD.deliveryInstallationType">
+      <path value="AD.deliveryInstallationType"/>
+      <definition value="Indicates the type of delivery installation (the facility to which the mail will be delivered prior to final shipping via the delivery mode.) Example: post office, letter carrier depot, community mail center, station, etc."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationType"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationType.partType">
+      <path value="AD.deliveryInstallationType.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationType.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DINST"/>
+    </element>
+    <element id="AD.deliveryInstallationArea">
+      <path value="AD.deliveryInstallationArea"/>
+      <definition value="The location of the delivery installation, usually a town or city, and is only required if the area is different from the municipality. Area to which mail delivery service is provided from any postal facility or service such as an individual letter carrier, rural route, or postal route."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationArea"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationArea.partType">
+      <path value="AD.deliveryInstallationArea.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationArea.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DINSTA"/>
+    </element>
+    <element id="AD.deliveryInstallationQualifier">
+      <path value="AD.deliveryInstallationQualifier"/>
+      <definition value="A number, letter or name identifying a delivery installation. E.g., for Station A, the delivery installation qualifier would be 'A'."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryInstallationQualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryInstallationQualifier.partType">
+      <path value="AD.deliveryInstallationQualifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryInstallationQualifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DINSTQ"/>
+    </element>
+    <element id="AD.deliveryMode">
+      <path value="AD.deliveryMode"/>
+      <definition value="Indicates the type of service offered, method of delivery. For example: post office box, rural route, general delivery, etc."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryMode"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryMode.partType">
+      <path value="AD.deliveryMode.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryMode.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DMOD"/>
+    </element>
+    <element id="AD.deliveryModeIdentifier">
+      <path value="AD.deliveryModeIdentifier"/>
+      <definition value="Represents the routing information such as a letter carrier route number. It is the identifying number of the designator (the box number or rural route number)."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.deliveryModeIdentifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.deliveryModeIdentifier.partType">
+      <path value="AD.deliveryModeIdentifier.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.deliveryModeIdentifier.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="DMODID"/>
+    </element>
+    <element id="AD.buildingNumberSuffix">
+      <path value="AD.buildingNumberSuffix"/>
+      <definition value="Any alphabetic character, fraction or other text that may appear after the numeric portion of a building number"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.buildingNumberSuffix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.buildingNumberSuffix.partType">
+      <path value="AD.buildingNumberSuffix.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.buildingNumberSuffix.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="BNS"/>
+    </element>
+    <element id="AD.postBox">
+      <path value="AD.postBox"/>
+      <definition value="A numbered box located in a post station."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.postBox"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.postBox.partType">
+      <path value="AD.postBox.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.postBox.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="POB"/>
+    </element>
+    <element id="AD.precinct">
+      <path value="AD.precinct"/>
+      <definition value="A subsection of a municipality"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="AD.precinct"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="AD.precinct.partType">
+      <path value="AD.precinct.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.precinct.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="PRE"/>
+    </element>
+    <element id="AD.other">
+      <path value="AD.other"/>
+      <representation value="xmlText"/>
+      <definition value="Textual representation of (part of) the address"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="AD.other"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
     <element id="AD.useablePeriod">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
         <valueString value="SXPR_TS"/>
       </extension>
-      <path value="AD.useablePeriod"/>
+      <path value="AD.useablePeriod[x]"/>
       <representation value="typeAttr"/>
       <label value="Useable Period"/>
       <definition value="A General Timing Specification (GTS) specifying the periods of time during which the address can be used. This is used to specify different addresses for different times of the week or year."/>
@@ -1802,17 +1839,6 @@
       </type>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
-      </type>
-    </element>
-    <element id="AD.isNotOrdered">
-      <path value="AD.isNotOrdered"/>
-      <representation value="xmlAttr"/>
-      <label value="Is Not Ordered"/>
-      <definition value="A boolean value specifying whether the order of the address parts is known or not. While the address parts are always a Sequence, the order in which they are presented may or may not be known. Where this matters, the isNotOrdered property can be used to convey this information."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
       </type>
     </element>
   </differential>

--- a/resources/ANY.xml
+++ b/resources/ANY.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ANY"/>
   <text>
@@ -25,7 +25,9 @@
   <snapshot>
     <element id="ANY">
       <path value="ANY"/>
-      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/><min value="1"/>
+      <short value="Data Value" />
+      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">
@@ -52,7 +54,8 @@
   <differential>
     <element id="ANY">
       <path value="ANY"/>
-      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/><min value="1"/>
+      <definition value="Defines the basic properties of every data value. This is an abstract type, meaning that no value can be just a data value without belonging to any concrete type. Every concrete type is a specialization of this general abstract DataValue type."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="ANY.nullFlavor">

--- a/resources/BL.xml
+++ b/resources/BL.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="BL"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="BL">
       <path value="BL"/>
-      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/><min value="1"/>
+      <short value="Boolean" />
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="BL.nullFlavor">
       <path value="BL.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -67,7 +69,8 @@
   <differential>
     <element id="BL">
       <path value="BL"/>
-      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/><min value="1"/>
+      <definition value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false, or, as any other value may be NULL."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="BL.value">

--- a/resources/CD.xml
+++ b/resources/CD.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CD"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CD">
       <path value="CD"/>
-      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/><min value="1"/>
+      <short value="Concept Descriptor" />
+      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CD.nullFlavor">
       <path value="CD.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -128,51 +130,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CD.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CD.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CD.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CD.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -209,11 +166,57 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="CD.originalText">
+      <path value="CD.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CD.qualifier">
+      <path value="CD.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.translation">
+      <path value="CD.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="CD">
       <path value="CD"/>
-      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/><min value="1"/>
+      <definition value="A concept descriptor represents any kind of concept usually by giving a code defined in a code system. A concept descriptor can contain the original text or phrase that served as the basis of the coding and one or more translations into different coding systems. A concept descriptor can also contain qualifiers to describe, e.g., the concept of a &#34;left foot&#34; as a postcoordinated term built from the primary code &#34;FOOT&#34; and the qualifier &#34;LEFT&#34;. In exceptional cases, the concept descriptor need not contain a code but only the original text describing that concept."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="CD.code">
@@ -271,36 +274,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CD.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CD.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CD.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CD.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -330,6 +303,36 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="CD.originalText">
+      <path value="CD.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CD.qualifier">
+      <path value="CD.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CD.translation">
+      <path value="CD.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
   </differential>

--- a/resources/CE.xml
+++ b/resources/CE.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CE"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CE">
       <path value="CE"/>
-      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/><min value="1"/>
+      <short value="Coded with Equivalents" />
+      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CE.nullFlavor">
       <path value="CE.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="CD.code">
+    <element id="CE.code">
       <path value="CE.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
@@ -64,7 +66,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystem">
+    <element id="CE.codeSystem">
       <path value="CE.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
@@ -80,7 +82,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemName">
+    <element id="CE.codeSystemName">
       <path value="CE.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
@@ -96,7 +98,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemVersion">
+    <element id="CE.codeSystemVersion">
       <path value="CE.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
@@ -112,7 +114,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.displayName">
+    <element id="CE.displayName">
       <path value="CE.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
@@ -128,52 +130,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CE.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CE.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CE.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
-    <element id="CD.valueSet">
+    <element id="CE.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -191,7 +148,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSetVersion">
+    <element id="CE.valueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -209,11 +166,57 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="CE.originalText">
+      <path value="CE.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CE.qualifier">
+      <path value="CE.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CE.translation">
+      <path value="CE.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="CE">
       <path value="CE"/>
-      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/><min value="1"/>
+      <definition value="Coded data, consists of a coded value (CV) and, optionally, coded value(s) from other coding systems that identify the same concept. Used when alternative codes may exist."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="CE.code">
@@ -266,39 +269,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CE.originalText">
-      <path value="CE.originalText"/>
-      <label value="Original Text"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CE.translation">
-      <path value="CE.translation"/>
-      <label value="Translation"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CE.qualifier">
-      <path value="CE.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CE.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -327,6 +297,39 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="CE.originalText">
+      <path value="CE.originalText"/>
+      <label value="Original Text"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CE.qualifier">
+      <path value="CE.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CE.translation">
+      <path value="CE.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
   </differential>

--- a/resources/CO.xml
+++ b/resources/CO.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CO"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CO">
       <path value="CO"/>
-      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/><min value="1"/>
+      <short value="Coded Ordinal" />
+      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CO.nullFlavor">
       <path value="CO.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="CD.code">
+    <element id="CO.code">
       <path value="CO.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
@@ -64,7 +66,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystem">
+    <element id="CO.codeSystem">
       <path value="CO.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
@@ -80,7 +82,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemName">
+    <element id="CO.codeSystemName">
       <path value="CO.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
@@ -96,7 +98,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemVersion">
+    <element id="CO.codeSystemVersion">
       <path value="CO.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
@@ -112,7 +114,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.displayName">
+    <element id="CO.displayName">
       <path value="CO.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
@@ -128,52 +130,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CO.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CO.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CO.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
-    <element id="CD.valueSet">
+    <element id="CO.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -191,7 +148,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSetVersion">
+    <element id="CO.valueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -209,11 +166,57 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="CO.originalText">
+      <path value="CO.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CO.qualifier">
+      <path value="CO.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CO.translation">
+      <path value="CO.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="CO">
       <path value="CO"/>
-      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/><min value="1"/>
+      <definition value="Coded data, where the domain from which the codeset comes is ordered. The Coded Ordinal data type adds semantics related to ordering so that models that make use of such domains may introduce model elements that involve statements about the order of the terms in a domain."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="CO.code">
@@ -266,39 +269,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CO.originalText">
-      <path value="CO.originalText"/>
-      <label value="Original Text"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CO.translation">
-      <path value="CO.translation"/>
-      <label value="Translation"/>
-      <min value="0"/>
-      <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CO.qualifier">
-      <path value="CO.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CO.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -327,6 +297,39 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="CO.originalText">
+      <path value="CO.originalText"/>
+      <label value="Original Text"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CO.qualifier">
+      <path value="CO.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CO.translation">
+      <path value="CO.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
   </differential>

--- a/resources/CR.xml
+++ b/resources/CR.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CR"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CR">
       <path value="CR"/>
-      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/><min value="1"/>
+      <short value="Concept Role" />
+      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CR.nullFlavor">
       <path value="CR.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -47,6 +49,22 @@
         <strength value="required"/>
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
+    </element>
+    <element id="CR.inverted">
+      <path value="CR.inverted"/>
+      <representation value="xmlAttr"/>
+      <label value="Inversion Indicator"/>
+      <definition value="Indicates if the sense of the role name is inverted. This can be used in cases where the underlying code system defines inversion but does not provide reciprocal pairs of role names. By default, inverted is false."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CR.inverted"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="boolean"/>
+      </type>
     </element>
     <element id="CR.name">
       <path value="CR.name"/>
@@ -78,6 +96,14 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
+  </snapshot>
+  <differential>
+    <element id="CR">
+      <path value="CR"/>
+      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
     <element id="CR.inverted">
       <path value="CR.inverted"/>
       <representation value="xmlAttr"/>
@@ -85,21 +111,9 @@
       <definition value="Indicates if the sense of the role name is inverted. This can be used in cases where the underlying code system defines inversion but does not provide reciprocal pairs of role names. By default, inverted is false."/>
       <min value="0"/>
       <max value="1"/>
-      <base>
-        <path value="CR.inverted"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
       <type>
         <code value="boolean"/>
       </type>
-    </element>
-  </snapshot>
-  <differential>
-    <element id="CR">
-      <path value="CR"/>
-      <definition value="A concept qualifier code with optionally named role. Both qualifier role and value codes must be defined by the coding system. For example, if SNOMED RT defines a concept &#34;leg&#34;, a role relation &#34;has-laterality&#34;, and another concept &#34;left&#34;, the concept role relation allows to add the qualifier &#34;has-laterality: left&#34; to a primary code &#34;leg&#34; to construct the meaning &#34;left leg&#34;."/><min value="1"/>
-      <max value="*"/>
     </element>
     <element id="CR.name">
       <path value="CR.name"/>
@@ -119,17 +133,6 @@
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CR.inverted">
-      <path value="CR.inverted"/>
-      <representation value="xmlAttr"/>
-      <label value="Inversion Indicator"/>
-      <definition value="Indicates if the sense of the role name is inverted. This can be used in cases where the underlying code system defines inversion but does not provide reciprocal pairs of role names. By default, inverted is false."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
       </type>
     </element>
   </differential>

--- a/resources/CS.xml
+++ b/resources/CS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CS"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CS">
       <path value="CS"/>
-      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
+      <short value="Coded Simple" />
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CS.nullFlavor">
       <path value="CS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="CD.code">
+    <element id="CS.code">
       <path value="CS.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
@@ -64,7 +66,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystem">
+    <element id="CS.codeSystem">
       <path value="CS.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
@@ -80,7 +82,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemName">
+    <element id="CS.codeSystemName">
       <path value="CS.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
@@ -96,7 +98,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemVersion">
+    <element id="CS.codeSystemVersion">
       <path value="CS.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
@@ -112,7 +114,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.displayName">
+    <element id="CS.displayName">
       <path value="CS.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
@@ -128,52 +130,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CS.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CS.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CS.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
-    <element id="CD.valueSet">
+    <element id="CS.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -191,7 +148,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSetVersion">
+    <element id="CS.valueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -209,11 +166,57 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="CS.originalText">
+      <path value="CS.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CS.qualifier">
+      <path value="CS.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CS.translation">
+      <path value="CS.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="CS">
       <path value="CS"/>
-      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="CS.code">
@@ -266,39 +269,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CS.originalText">
-      <path value="CS.originalText"/>
-      <label value="Original Text"/>
-      <min value="0"/>
-      <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CS.translation">
-      <path value="CS.translation"/>
-      <label value="Translation"/>
-      <min value="0"/>
-      <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CS.qualifier">
-      <path value="CS.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CS.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -327,6 +297,39 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="CS.originalText">
+      <path value="CS.originalText"/>
+      <label value="Original Text"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CS.qualifier">
+      <path value="CS.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CS.translation">
+      <path value="CS.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
   </differential>

--- a/resources/CV.xml
+++ b/resources/CV.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="CV"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="CV">
       <path value="CV"/>
-      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
+      <short value="Coded Value" />
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="CV.nullFlavor">
       <path value="CV.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="CD.code">
+    <element id="CV.code">
       <path value="CV.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
@@ -64,7 +66,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystem">
+    <element id="CV.codeSystem">
       <path value="CV.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
@@ -80,7 +82,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemName">
+    <element id="CV.codeSystemName">
       <path value="CV.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
@@ -96,7 +98,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemVersion">
+    <element id="CV.codeSystemVersion">
       <path value="CV.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
@@ -112,7 +114,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.displayName">
+    <element id="CV.displayName">
       <path value="CV.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
@@ -128,52 +130,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.originalText">
-      <path value="CV.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="CV.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="CV.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
-    <element id="CD.valueSet">
+    <element id="CV.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -191,7 +148,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSetVersion">
+    <element id="CV.valueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
@@ -209,11 +166,57 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="CV.originalText">
+      <path value="CV.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CV.qualifier">
+      <path value="CV.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CV.translation">
+      <path value="CV.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="CV">
       <path value="CV"/>
-      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/><min value="1"/>
+      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="CV.code">
@@ -266,39 +269,6 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CV.originalText">
-      <path value="CV.originalText"/>
-      <label value="Original Text"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CV.translation">
-      <path value="CV.translation"/>
-      <label value="Translation"/>
-      <min value="0"/>
-      <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CV.qualifier">
-      <path value="CV.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="0"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
     <element id="CV.valueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
@@ -327,6 +297,39 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+      </type>
+    </element>
+    <element id="CV.originalText">
+      <path value="CV.originalText"/>
+      <label value="Original Text"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="CV.qualifier">
+      <path value="CV.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="CV.translation">
+      <path value="CV.translation"/>
+      <label value="Translation"/>
+      <min value="0"/>
+      <max value="0"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>
     </element>
   </differential>

--- a/resources/ED.xml
+++ b/resources/ED.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ED"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="ED">
       <path value="ED"/>
-      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/><min value="1"/>
+      <short value="Encapsulated Data" />
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="ED.nullFlavor">
       <path value="ED.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,37 +50,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="ED.representation">
-      <path value="ED.representation"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.representation"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.mediaType">
-      <path value="ED.mediaType"/>
-      <representation value="xmlAttr"/>
-      <label value="Media Type"/>
-      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.mediaType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
     <element id="ED.charset">
       <path value="ED.charset"/>
       <representation value="xmlAttr"/>
@@ -88,22 +59,6 @@
       <max value="1"/>
       <base>
         <path value="ED.charset"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.language">
-      <path value="ED.language"/>
-      <representation value="xmlAttr"/>
-      <label value="Language"/>
-      <definition value="For character based information the language property specifies the human language of the text."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.language"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -167,8 +122,55 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
-    <element id="ED.data">
-      <path value="ED.data"/>
+    <element id="ED.language">
+      <path value="ED.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.language"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.mediaType">
+      <path value="ED.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.mediaType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.representation">
+      <path value="ED.representation"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.representation"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.data[x]">
+      <path value="ED.data[x]"/>
       <representation value="xmlText"/>
       <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.)"/>
       <min value="0"/>
@@ -219,45 +221,15 @@
   <differential>
     <element id="ED">
       <path value="ED"/>
-      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/><min value="1"/>
+      <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.) Instead of the data itself, an ED may contain only a reference (see TEL.) Note that the ST data type is a specialization of when the is text/plain."/>
+      <min value="1"/>
       <max value="*"/>
-    </element>
-    <element id="ED.representation">
-      <path value="ED.representation"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.mediaType">
-      <path value="ED.mediaType"/>
-      <representation value="xmlAttr"/>
-      <label value="Media Type"/>
-      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
     </element>
     <element id="ED.charset">
       <path value="ED.charset"/>
       <representation value="xmlAttr"/>
       <label value="Charset"/>
       <definition value="For character-based encoding types, this property specifies the character set and character encoding used. The charset shall be identified by an Internet Assigned Numbers Authority (IANA) Charset Registration [] in accordance with RFC 2978 []."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ED.language">
-      <path value="ED.language"/>
-      <representation value="xmlAttr"/>
-      <label value="Language"/>
-      <definition value="For character based information the language property specifies the human language of the text."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -305,8 +277,39 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
-    <element id="ED.data">
-      <path value="ED.data"/>
+    <element id="ED.language">
+      <path value="ED.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.mediaType">
+      <path value="ED.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.representation">
+      <path value="ED.representation"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ED.data[x]">
+      <path value="ED.data[x]"/>
       <representation value="xmlText"/>
       <definition value="Data that is primarily intended for human interpretation or for further machine processing is outside the scope of HL7. This includes unformatted or formatted written language, multimedia data, or structured information as defined by a different standard (e.g., XML-signatures.)"/>
       <min value="0"/>

--- a/resources/EIVL_TS.xml
+++ b/resources/EIVL_TS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="EIVL_TS"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="EIVL_TS">
       <path value="EIVL_TS"/>
-      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
+      <short value="Event Related Interval of Timestamps" />
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="EIVL_TS.nullFlavor">
       <path value="EIVL_TS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,37 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="TS.value">
+    <element id="EIVL_TS.inclusive">
+      <path value="EIVL_TS.inclusive"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="TS.inclusive"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
+    <element id="EIVL_TS.operator">
+      <path value="EIVL_TS.operator"/>
+      <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="SXCM_TS.operator"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="EIVL_TS.value">
       <extension url="http://www.healthintersections.com.au/fhir/StructureDefinition/elementdefinition-dateformat">
         <valueString value="v3"/>
       </extension>
@@ -64,36 +96,6 @@
       </base>
       <type>
         <code value="dateTime"/>
-      </type>
-    </element>
-    <element id="TS.inclusive">
-      <path value="EIVL_TS.inclusive"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="TS.inclusive"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="SXCM_TS.operator">
-      <path value="EIVL_TS.operator"/>
-      <representation value="xmlAttr"/>
-      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="SXCM_TS.operator"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
       </type>
     </element>
     <element id="EIVL_TS.event">
@@ -130,7 +132,8 @@
   <differential>
     <element id="EIVL_TS">
       <path value="EIVL_TS"/>
-      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="EIVL_TS.event">

--- a/resources/EN.xml
+++ b/resources/EN.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="EN"/>
   <text>
@@ -28,10 +28,12 @@
   <snapshot>
     <element id="EN">
       <path value="EN"/>
-      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/><min value="1"/>
+      <short value="Entity Name" />
+      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="EN.nullFlavor">
       <path value="EN.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -51,6 +53,22 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
+    <element id="EN.use">
+      <path value="EN.use"/>
+      <representation value="xmlAttr"/>
+      <label value="Use Code"/>
+      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.use"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
     <element id="EN.delimiter">
       <path value="EN.delimiter"/>
       <definition value="A delimiter has no meaning other than being literally printed in this name representation. A delimiter has no implicit leading and trailing white space."/>
@@ -62,7 +80,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
       </type>
     </element>
     <element id="EN.delimiter.partType">
@@ -71,14 +89,14 @@
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="EN.delimiter.partType"/>
+        <path value="ENXP.partType"/>
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="DEL"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="DEL"/>
     </element>
     <element id="EN.delimiter.qualifier">
       <path value="EN.delimiter.qualifier"/>
@@ -86,7 +104,7 @@
       <min value="0"/>
       <max value="*"/>
       <base>
-        <path value="EN.delimiter.qualifier"/>
+        <path value="ENXP.qualifier"/>
         <min value="0"/>
         <max value="*"/>
       </base>
@@ -94,6 +112,7 @@
         <code value="code"/>
       </type>
       <binding>
+        <strength value="required" />
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
@@ -108,7 +127,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
       </type>
     </element>
     <element id="EN.family.partType">
@@ -117,14 +136,14 @@
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="EN.family.partType"/>
+        <path value="ENXP.partType"/>
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="FAM"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="FAM"/>
     </element>
     <element id="EN.family.qualifier">
       <path value="EN.family.qualifier"/>
@@ -132,7 +151,7 @@
       <min value="0"/>
       <max value="*"/>
       <base>
-        <path value="EN.family.qualifier"/>
+        <path value="ENXP.qualifier"/>
         <min value="0"/>
         <max value="*"/>
       </base>
@@ -140,6 +159,7 @@
         <code value="code"/>
       </type>
       <binding>
+        <strength value="required" />
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
@@ -154,7 +174,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
       </type>
     </element>
     <element id="EN.given.partType">
@@ -163,14 +183,14 @@
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="EN.given.partType"/>
+        <path value="ENXP.partType"/>
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="GIV"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="GIV"/>
     </element>
     <element id="EN.given.qualifier">
       <path value="EN.given.qualifier"/>
@@ -178,7 +198,7 @@
       <min value="0"/>
       <max value="*"/>
       <base>
-        <path value="EN.given.qualifier"/>
+        <path value="ENXP.qualifier"/>
         <min value="0"/>
         <max value="*"/>
       </base>
@@ -186,6 +206,7 @@
         <code value="code"/>
       </type>
       <binding>
+        <strength value="required" />
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
@@ -200,7 +221,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
       </type>
     </element>
     <element id="EN.prefix.partType">
@@ -209,14 +230,14 @@
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="EN.prefix.partType"/>
+        <path value="ENXP.partType"/>
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="PFX"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="PFX"/>
     </element>
     <element id="EN.prefix.qualifier">
       <path value="EN.prefix.qualifier"/>
@@ -224,7 +245,7 @@
       <min value="0"/>
       <max value="*"/>
       <base>
-        <path value="EN.prefix.qualifier"/>
+        <path value="ENXP.qualifier"/>
         <min value="0"/>
         <max value="*"/>
       </base>
@@ -232,6 +253,7 @@
         <code value="code"/>
       </type>
       <binding>
+        <strength value="required" />
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
@@ -246,7 +268,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
       </type>
     </element>
     <element id="EN.suffix.partType">
@@ -255,14 +277,14 @@
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="EN.suffix.partType"/>
+        <path value="ENXP.partType"/>
         <min value="0"/>
         <max value="1"/>
       </base>
-      <fixedCode value="SFX"/>
       <type>
         <code value="code"/>
       </type>
+      <fixedCode value="SFX"/>
     </element>
     <element id="EN.suffix.qualifier">
       <path value="EN.suffix.qualifier"/>
@@ -270,7 +292,7 @@
       <min value="0"/>
       <max value="*"/>
       <base>
-        <path value="EN.suffix.qualifier"/>
+        <path value="ENXP.qualifier"/>
         <min value="0"/>
         <max value="*"/>
       </base>
@@ -278,6 +300,7 @@
         <code value="code"/>
       </type>
       <binding>
+        <strength value="required" />
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
@@ -294,22 +317,6 @@
       </base>
       <type>
         <code value="string"/>
-      </type>
-    </element>
-    <element id="EN.use">
-      <path value="EN.use"/>
-      <representation value="xmlAttr"/>
-      <label value="Use Code"/>
-      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="EN.use"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="code"/>
       </type>
     </element>
     <element id="EN.validTime">
@@ -331,57 +338,9 @@
   <differential>
     <element id="EN">
       <path value="EN"/>
-      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/><min value="1"/>
+      <definition value="A name for a person, organization, place or thing. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for entity name values are &#34;Jim Bob Walton, Jr.&#34;, &#34;Health Level Seven, Inc.&#34;, &#34;Lake Tahoe&#34;, etc. An entity name may be as simple as a character string or may consist of several entity name parts, such as, &#34;Jim&#34;, &#34;Bob&#34;, &#34;Walton&#34;, and &#34;Jr.&#34;, &#34;Health Level Seven&#34; and &#34;Inc.&#34;, &#34;Lake&#34; and &#34;Tahoe&#34;."/>
+      <min value="1"/>
       <max value="*"/>
-    </element>
-    <element id="EN.delimiter">
-      <path value="EN.delimiter"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="EN.family">
-      <path value="EN.family"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="EN.given">
-      <path value="EN.given"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="EN.prefix">
-      <path value="EN.prefix"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="EN.suffix">
-      <path value="EN.suffix"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
-      </type>
-    </element>
-    <element id="EN.other">
-      <path value="EN.other"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="EN.use">
       <path value="EN.use"/>
@@ -392,6 +351,55 @@
       <max value="*"/>
       <type>
         <code value="code"/>
+      </type>
+    </element>
+    <element id="EN.delimiter">
+      <path value="EN.delimiter"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="EN.family">
+      <path value="EN.family"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="EN.given">
+      <path value="EN.given"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="EN.prefix">
+      <path value="EN.prefix"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="EN.suffix">
+      <path value="EN.suffix"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="EN.other">
+      <path value="EN.other"/>
+      <representation value="xmlText"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
       </type>
     </element>
     <element id="EN.validTime">

--- a/resources/ENXP.xml
+++ b/resources/ENXP.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ENXP"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>A character string token representing a part of a name. May have a type code signifying the role of the part in the whole entity name, and a qualifier code for more detail about the name part type. Typical name parts for person names are given names, and family names, titles, etc.</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+  <name value="ENXP"/>
+  <title value="ENXP: Entity Name Part (V3 Data Type)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A character string token representing a part of a name. May have a type code signifying the role of the part in the whole entity name, and a qualifier code for more detail about the name part type. Typical name parts for person names are given names, and family names, titles, etc."/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="ENXP"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+  <derivation value="specialization"/>
+  <snapshot>
+    <element id="ENXP">
+      <path value="ENXP"/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="ENXP.nullFlavor">
+      <path value="ENXP.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="ENXP.partType">
+      <path value="ENXP.partType"/>
+      <representation value="xmlAttr"/>
+      <label value="Name Part Type Code"/>
+      <definition value="Indicates whether the name part is a given name, family name, prefix, suffix, etc."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ENXP.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartType"/>
+      </binding>
+    </element>
+    <element id="ENXP.qualifier">
+      <path value="ENXP.qualifier"/>
+      <representation value="xmlAttr"/>
+      <label value="Qualifier Code"/>
+      <definition value="qualifier is a set of codes each of which specifies a certain subcategory of the name part in addition to the main name part type. For example, a given name may be flagged as a nickname, a family name may be a pseudonym or a name of public records."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="ENXP.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
+    <element id="ENXP.value">
+      <path value="ENXP.value"/>
+      <representation value="xmlText"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ENXP.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="ENXP">
+      <path value="ENXP"/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="ENXP.nullFlavor">
+      <path value="ENXP.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="ENXP.partType">
+      <path value="ENXP.partType"/>
+      <representation value="xmlAttr"/>
+      <label value="Name Part Type Code"/>
+      <definition value="Indicates whether the name part is a given name, family name, prefix, suffix, etc."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ENXP.partType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartType"/>
+      </binding>
+    </element>
+    <element id="ENXP.qualifier">
+      <path value="ENXP.qualifier"/>
+      <representation value="xmlAttr"/>
+      <label value="Qualifier Code"/>
+      <definition value="qualifier is a set of codes each of which specifies a certain subcategory of the name part in addition to the main name part type. For example, a given name may be flagged as a nickname, a family name may be a pseudonym or a name of public records."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="ENXP.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+      </binding>
+    </element>
+    <element id="ENXP.value">
+      <path value="ENXP.value"/>
+      <representation value="xmlText"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/II.xml
+++ b/resources/II.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="II"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="II">
       <path value="II"/>
-      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/><min value="1"/>
+      <short value="Instance Identifier" />
+      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="II.nullFlavor">
       <path value="II.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -47,38 +49,6 @@
         <strength value="required"/>
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
-    </element>
-    <element id="II.root">
-      <path value="II.root"/>
-      <representation value="xmlAttr"/>
-      <label value="Root"/>
-      <definition value="A unique identifier that guarantees the global uniqueness of the instance identifier. The root alone may be the entire instance identifier."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="II.root"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="II.extension">
-      <path value="II.extension"/>
-      <representation value="xmlAttr"/>
-      <label value="Extension"/>
-      <definition value="A character string as a unique identifier within the scope of the identifier root."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="II.extension"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="II.assigningAuthorityName">
       <path value="II.assigningAuthorityName"/>
@@ -112,12 +82,21 @@
         <code value="boolean"/>
       </type>
     </element>
-  </snapshot>
-  <differential>
-    <element id="II">
-      <path value="II"/>
-      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/><min value="1"/>
-      <max value="*"/>
+    <element id="II.extension">
+      <path value="II.extension"/>
+      <representation value="xmlAttr"/>
+      <label value="Extension"/>
+      <definition value="A character string as a unique identifier within the scope of the identifier root."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="II.extension"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
     </element>
     <element id="II.root">
       <path value="II.root"/>
@@ -126,20 +105,22 @@
       <definition value="A unique identifier that guarantees the global uniqueness of the instance identifier. The root alone may be the entire instance identifier."/>
       <min value="0"/>
       <max value="1"/>
+      <base>
+        <path value="II.root"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
       <type>
         <code value="string"/>
       </type>
     </element>
-    <element id="II.extension">
-      <path value="II.extension"/>
-      <representation value="xmlAttr"/>
-      <label value="Extension"/>
-      <definition value="A character string as a unique identifier within the scope of the identifier root."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
+  </snapshot>
+  <differential>
+    <element id="II">
+      <path value="II"/>
+      <definition value="An identifier that uniquely identifies a thing or object. Examples are object identifier for HL7 RIM objects, medical record number, order id, service catalog item id, Vehicle Identification Number (VIN), etc. Instance identifiers are defined based on ISO object identifiers."/>
+      <min value="1"/>
+      <max value="*"/>
     </element>
     <element id="II.assigningAuthorityName">
       <path value="II.assigningAuthorityName"/>
@@ -161,6 +142,28 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+      </type>
+    </element>
+    <element id="II.extension">
+      <path value="II.extension"/>
+      <representation value="xmlAttr"/>
+      <label value="Extension"/>
+      <definition value="A character string as a unique identifier within the scope of the identifier root."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="II.root">
+      <path value="II.root"/>
+      <representation value="xmlAttr"/>
+      <label value="Root"/>
+      <definition value="A unique identifier that guarantees the global uniqueness of the instance identifier. The root alone may be the entire instance identifier."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
       </type>
     </element>
   </differential>

--- a/resources/INT.xml
+++ b/resources/INT.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="INT"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="INT">
       <path value="INT"/>
-      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/><min value="1"/>
+      <short value="Integer" />
+      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="INT.nullFlavor">
       <path value="INT.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -67,7 +69,8 @@
   <differential>
     <element id="INT">
       <path value="INT"/>
-      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/><min value="1"/>
+      <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="INT.value">

--- a/resources/IVL_INT.xml
+++ b/resources/IVL_INT.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="IVL_INT"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_INT">
       <path value="IVL_INT"/>
+      <short value="Interval of Integers" />
       <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>

--- a/resources/IVL_PQ.xml
+++ b/resources/IVL_PQ.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="IVL_PQ"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_PQ">
       <path value="IVL_PQ"/>
+      <short value="Interval of Physical Quantities" />
       <definition value="Interval of physical quantities"/>
       <min value="1"/>
       <max value="*"/>
@@ -43,22 +44,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="IVL_PQ.value">
-      <path value="IVL_PQ.value"/>
-      <representation value="xmlAttr"/>
-      <label value="Maginitude Value"/>
-      <definition value="The magnitude of the quantity measured in terms of the unit."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="PQ.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="decimal"/>
-      </type>
-    </element>
     <element id="IVL_PQ.unit">
       <path value="IVL_PQ.unit"/>
       <representation value="xmlAttr"/>
@@ -73,6 +58,22 @@
       </base>
       <type>
         <code value="code"/>
+      </type>
+    </element>
+    <element id="IVL_PQ.value">
+      <path value="IVL_PQ.value"/>
+      <representation value="xmlAttr"/>
+      <label value="Maginitude Value"/>
+      <definition value="The magnitude of the quantity measured in terms of the unit."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="PQ.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="decimal"/>
       </type>
     </element>
     <element id="IVL_PQ.low">
@@ -142,22 +143,6 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL_PQ.value">
-      <path value="IVL_PQ.value"/>
-      <representation value="xmlAttr"/>
-      <label value="Maginitude Value"/>
-      <definition value="The magnitude of the quantity measured in terms of the unit."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="PQ.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="decimal"/>
-      </type>
-    </element>
     <element id="IVL_PQ.unit">
       <path value="IVL_PQ.unit"/>
       <representation value="xmlAttr"/>
@@ -172,6 +157,22 @@
       </base>
       <type>
         <code value="code"/>
+      </type>
+    </element>
+    <element id="IVL_PQ.value">
+      <path value="IVL_PQ.value"/>
+      <representation value="xmlAttr"/>
+      <label value="Maginitude Value"/>
+      <definition value="The magnitude of the quantity measured in terms of the unit."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="PQ.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="decimal"/>
       </type>
     </element>
     <element id="IVL_PQ.low">

--- a/resources/IVL_TS.xml
+++ b/resources/IVL_TS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="IVL_TS"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,6 +19,7 @@
   <snapshot>
     <element id="IVL_TS">
       <path value="IVL_TS"/>
+      <short value="Interval of Timestamps" />
       <definition value="Interval of timestamps"/>
       <min value="1"/>
       <max value="*"/>
@@ -76,7 +77,7 @@
         <code value="boolean"/>
       </type>
     </element>
-    <element id="SXCM_TS.operator">
+    <element id="IVL_TS.operator">
       <path value="IVL_TS.operator"/>
       <representation value="xmlAttr"/>
       <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>

--- a/resources/InfrastructureRoot.xml
+++ b/resources/InfrastructureRoot.xml
@@ -30,7 +30,7 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="InfrastructureRoot.nullFlavor">
       <path value="InfrastructureRoot.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>

--- a/resources/MO.xml
+++ b/resources/MO.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="MO"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="MO">
       <path value="MO"/>
-      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/><min value="1"/>
+      <short value="Money" />
+      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="MO.nullFlavor">
       <path value="MO.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,21 +50,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="MO.value">
-      <path value="MO.value"/>
-      <label value="Value"/>
-      <definition value="The magnitude of the monetary amount in terms of the currency unit."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="MO.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/REAL"/>
-      </type>
-    </element>
     <element id="MO.currency">
       <path value="MO.currency"/>
       <label value="Currency"/>
@@ -78,22 +65,28 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
       </type>
     </element>
-  </snapshot>
-  <differential>
-    <element id="MO">
-      <path value="MO"/>
-      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/><min value="1"/>
-      <max value="*"/>
-    </element>
     <element id="MO.value">
       <path value="MO.value"/>
       <label value="Value"/>
       <definition value="The magnitude of the monetary amount in terms of the currency unit."/>
       <min value="0"/>
       <max value="1"/>
+      <base>
+        <path value="MO.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/REAL"/>
       </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="MO">
+      <path value="MO"/>
+      <definition value="A monetary amount is a quantity expressing the amount of money in some currency. Currencies are the units in which monetary amounts are denominated in different economic regions. While the monetary amount is a single kind of quantity (money) the exchange rates between the different units are variable. This is the principle difference between physical quantity and monetary amounts, and the reason why currency units are not physical units."/>
+      <min value="1"/>
+      <max value="*"/>
     </element>
     <element id="MO.currency">
       <path value="MO.currency"/>
@@ -103,6 +96,16 @@
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
+      </type>
+    </element>
+    <element id="MO.value">
+      <path value="MO.value"/>
+      <label value="Value"/>
+      <definition value="The magnitude of the monetary amount in terms of the currency unit."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/REAL"/>
       </type>
     </element>
   </differential>

--- a/resources/ON.xml
+++ b/resources/ON.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ON"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are "Health Level Seven, Inc.", "Hospital", etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, "Health Level 7", "Inc.". ON differs from EN because certain person related name parts are not possible.</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-xml-no-order">
+    <valueBoolean value="true"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/ON"/>
+  <name value="ON"/>
+  <title value="ON: OrganizationName (V3 Data Type)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="ON"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+  <derivation value="specialization"/>
+  <snapshot>
+    <element id="ON">
+      <path value="ON"/>
+      <short value="Organization Name" />
+      <definition value="A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="ON.nullFlavor">
+      <path value="ON.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="ON.use">
+      <path value="ON.use"/>
+      <representation value="xmlAttr"/>
+      <label value="Use Code"/>
+      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.use"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-OrganizationNameUse"/>
+      </binding>
+    </element>
+    <element id="ON.delimiter">
+      <path value="ON.delimiter"/>
+      <definition value="A delimiter has no meaning other than being literally printed in this name representation. A delimiter has no implicit leading and trailing white space."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.delimiter"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="ON.family">
+      <path value="ON.family"/>
+      <definition value="Family name, this is the name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.family"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="ON.given">
+      <path value="ON.given"/>
+      <definition value="Given name (don't call it &quot;first name&quot; since this given names do not always come first)"/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.given"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="ON.prefix">
+      <path value="ON.prefix"/>
+      <definition value="A prefix has a strong association to the immediately following name part. A prefix has no implicit trailing white space (it has implicit leading white space though). Note that prefixes can be inverted."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.prefix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="ON.suffix">
+      <path value="ON.suffix"/>
+      <definition value="A suffix has a strong association to the immediately preceding name part. A prefix has no implicit leading white space (it has implicit trailing white space though). Suffices can not be inverted."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.suffix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="ON.other">
+      <path value="ON.other"/>
+      <representation value="xmlText" />
+      <definition value="Unstructured textual represention of the entity name"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.other"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="ON.validTime">
+      <path value="ON.validTime"/>
+      <label value="Valid Time"/>
+      <definition value="An interval of time specifying the time during which the name is or was used for the entity. This accomodates the fact that people change names for people, places and things."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.validTime"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
+      </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="ON">
+      <path value="ON"/>
+      <definition value="A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="ON.use">
+      <path value="ON.use"/>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-OrganizationNameUse"/>
+      </binding>
+    </element>
+    <element id="ON.family">
+      <path value="ON.family"/>
+      <max value="0"/>
+    </element>
+    <element id="ON.given">
+      <path value="ON.given"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/PIVL_TS.xml
+++ b/resources/PIVL_TS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="PIVL_TS"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="PIVL_TS">
       <path value="PIVL_TS"/>
-      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
+      <short value="Periodic Interval of Timestamps" />
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="PIVL_TS.nullFlavor">
       <path value="PIVL_TS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="TS.value">
+    <element id="PIVL_TS.value">
       <extension url="http://www.healthintersections.com.au/fhir/StructureDefinition/elementdefinition-dateformat">
         <valueString value="v3"/>
       </extension>
@@ -66,7 +68,7 @@
         <code value="dateTime"/>
       </type>
     </element>
-    <element id="TS.inclusive">
+    <element id="PIVL_TS.inclusive">
       <path value="PIVL_TS.inclusive"/>
       <representation value="xmlAttr"/>
       <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
@@ -81,7 +83,7 @@
         <code value="boolean"/>
       </type>
     </element>
-    <element id="SXCM_TS.operator">
+    <element id="PIVL_TS.operator">
       <path value="PIVL_TS.operator"/>
       <representation value="xmlAttr"/>
       <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
@@ -162,7 +164,8 @@
   <differential>
     <element id="PIVL_TS">
       <path value="PIVL_TS"/>
-      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/><min value="1"/>
+      <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="PIVL_TS.phase">

--- a/resources/PN.xml
+++ b/resources/PN.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="PN"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>A name for a person. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for person name values are "Jim Bob Walton, Jr.", "Adam Everyman", etc. A person name may be as simple as a character string or may consist of several person name parts, such as, "Jim", "Bob", "Walton", and "Jr.". PN differs from EN because the qualifier type cannot include LS (Legal Status).</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-xml-no-order">
+    <valueBoolean value="true"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/PN"/>
+  <name value="PN"/>
+  <title value="PN: PersonName (V3 Data Type)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A name for a person. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for person name values are &quot;Jim Bob Walton, Jr.&quot;, &quot;Adam Everyman&quot;, etc. A person name may be as simple as a character string or may consist of several person name parts, such as, &quot;Jim&quot;, &quot;Bob&quot;, &quot;Walton&quot;, and &quot;Jr.&quot;. PN differs from EN because the qualifier type cannot include LS (Legal Status)."/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="PN"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+  <derivation value="specialization"/>
+  <snapshot>
+    <element id="PN">
+      <path value="PN"/>
+      <short value="Person Name" />
+      <definition value="A name for a person. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for person name values are &quot;Jim Bob Walton, Jr.&quot;, &quot;Adam Everyman&quot;, etc. A person name may be as simple as a character string or may consist of several person name parts, such as, &quot;Jim&quot;, &quot;Bob&quot;, &quot;Walton&quot;, and &quot;Jr.&quot;. PN differs from EN because the qualifier type cannot include LS (Legal Status)."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="PN.nullFlavor">
+      <path value="PN.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="PN.use">
+      <path value="PN.use"/>
+      <representation value="xmlAttr"/>
+      <label value="Use Code"/>
+      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.use"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-PersonNameUse"/>
+      </binding>
+    </element>
+    <element id="PN.delimiter">
+      <path value="PN.delimiter"/>
+      <definition value="A delimiter has no meaning other than being literally printed in this name representation. A delimiter has no implicit leading and trailing white space."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.delimiter"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="PN.family">
+      <path value="PN.family"/>
+      <definition value="Family name, this is the name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.family"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="PN.given">
+      <path value="PN.given"/>
+      <definition value="Given name (don't call it &quot;first name&quot; since this given names do not always come first)"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.given"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="PN.prefix">
+      <path value="PN.prefix"/>
+      <definition value="A prefix has a strong association to the immediately following name part. A prefix has no implicit trailing white space (it has implicit leading white space though). Note that prefixes can be inverted."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.prefix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="PN.suffix">
+      <path value="PN.suffix"/>
+      <definition value="A suffix has a strong association to the immediately preceding name part. A prefix has no implicit leading white space (it has implicit trailing white space though). Suffices can not be inverted."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.suffix"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="PN.other">
+      <path value="PN.other"/>
+      <representation value="xmlText"/>
+      <definition value="Unstructured textual represention of the entity name"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.other"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="PN.validTime">
+      <path value="PN.validTime"/>
+      <label value="Valid Time"/>
+      <definition value="An interval of time specifying the time during which the name is or was used for the entity. This accomodates the fact that people change names for people, places and things."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.validTime"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
+      </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="PN">
+      <path value="PN"/>
+      <definition value="A name for a person. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for person name values are &quot;Jim Bob Walton, Jr.&quot;, &quot;Adam Everyman&quot;, etc. A person name may be as simple as a character string or may consist of several person name parts, such as, &quot;Jim&quot;, &quot;Bob&quot;, &quot;Walton&quot;, and &quot;Jr.&quot;. PN differs from EN because the qualifier type cannot include LS (Legal Status)."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="PN.use">
+      <path value="PN.use"/>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-PersonNameUse"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/PQ.xml
+++ b/resources/PQ.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="PQ"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="PQ">
       <path value="PQ"/>
-      <definition value="A dimensioned quantity expressing the result of a measurement act."/><min value="1"/>
+      <short value="Physical Quantities" />
+      <definition value="A dimensioned quantity expressing the result of a measurement act."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="PQ.nullFlavor">
       <path value="PQ.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,20 +50,19 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="PQ.value">
-      <path value="PQ.value"/>
+    <element id="PQ.inclusive">
+      <path value="PQ.inclusive"/>
       <representation value="xmlAttr"/>
-      <label value="Maginitude Value"/>
-      <definition value="The magnitude of the quantity measured in terms of the unit."/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="PQ.value"/>
+        <path value="PQ.inclusive"/>
         <min value="0"/>
         <max value="1"/>
       </base>
       <type>
-        <code value="decimal"/>
+        <code value="boolean"/>
       </type>
     </element>
     <element id="PQ.unit">
@@ -76,24 +77,25 @@
         <min value="0"/>
         <max value="1"/>
       </base>
-      <defaultValueCode value="1"/>
       <type>
         <code value="code"/>
       </type>
+      <defaultValueCode value="1"/>
     </element>
-    <element id="PQ.inclusive">
-      <path value="PQ.inclusive"/>
+    <element id="PQ.value">
+      <path value="PQ.value"/>
       <representation value="xmlAttr"/>
-      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
+      <label value="Maginitude Value"/>
+      <definition value="The magnitude of the quantity measured in terms of the unit."/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="PQ.inclusive"/>
+        <path value="PQ.value"/>
         <min value="0"/>
         <max value="1"/>
       </base>
       <type>
-        <code value="boolean"/>
+        <code value="decimal"/>
       </type>
     </element>
     <element id="PQ.translation">
@@ -115,18 +117,17 @@
   <differential>
     <element id="PQ">
       <path value="PQ"/>
-      <definition value="A dimensioned quantity expressing the result of a measurement act."/><min value="1"/>
+      <definition value="A dimensioned quantity expressing the result of a measurement act."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="PQ.value">
-      <path value="PQ.value"/>
+    <element id="PQ.inclusive">
+      <path value="PQ.inclusive"/>
       <representation value="xmlAttr"/>
-      <label value="Maginitude Value"/>
-      <definition value="The magnitude of the quantity measured in terms of the unit."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="decimal"/>
+        <code value="boolean"/>
       </type>
     </element>
     <element id="PQ.unit">
@@ -139,14 +140,17 @@
       <type>
         <code value="code"/>
       </type>
+      <defaultValueCode value="1"/>
     </element>
-    <element id="PQ.inclusive">
-      <path value="PQ.inclusive"/>
+    <element id="PQ.value">
+      <path value="PQ.value"/>
       <representation value="xmlAttr"/>
+      <label value="Maginitude Value"/>
+      <definition value="The magnitude of the quantity measured in terms of the unit."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="boolean"/>
+        <code value="decimal"/>
       </type>
     </element>
     <element id="PQ.translation">

--- a/resources/PQR.xml
+++ b/resources/PQR.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="PQR"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="PQR">
       <path value="PQR"/>
-      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/><min value="1"/>
+      <short value="Physical Quantity Representation" />
+      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="PQR.nullFlavor">
       <path value="PQR.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,7 +50,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="CD.code">
+    <element id="PQR.code">
       <path value="PQR.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
@@ -64,7 +66,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystem">
+    <element id="PQR.codeSystem">
       <path value="PQR.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
@@ -80,7 +82,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemName">
+    <element id="PQR.codeSystemName">
       <path value="PQR.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
@@ -96,7 +98,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.codeSystemVersion">
+    <element id="PQR.codeSystemVersion">
       <path value="PQR.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
@@ -112,7 +114,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.displayName">
+    <element id="PQR.displayName">
       <path value="PQR.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
@@ -121,69 +123,6 @@
       <max value="1"/>
       <base>
         <path value="CD.displayName"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="CD.originalText">
-      <path value="PQR.originalText"/>
-      <label value="Original Text"/>
-      <definition value="The text or phrase used as the basis for the coding."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.originalText"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
-    </element>
-    <element id="CD.translation">
-      <path value="PQR.translation"/>
-      <label value="Translation"/>
-      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="CD.translation"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
-      </type>
-    </element>
-    <element id="CD.qualifier">
-      <path value="PQR.qualifier"/>
-      <label value="Qualifier"/>
-      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
-      <min value="0"/>
-      <max value="*"/>
-      <base>
-        <path value="CD.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
-      </type>
-    </element>
-    <element id="CD.valueSetVersion">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-        <valueUri value="urn:hl7-org:sdtc"/>
-      </extension>
-      <path value="PQR.valueSetVersion"/>
-      <representation value="xmlAttr"/>
-      <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="CD.valueSetVersion"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -207,11 +146,93 @@
         <code value="decimal"/>
       </type>
     </element>
+    <element id="PQR.valueSet">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="PQR.valueSet"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+          <path value="PQR.valueSet"/>
+          <min value="0"/>
+          <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="PQR.valueSetVersion">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <path value="PQR.valueSetVersion"/>
+      <representation value="xmlAttr"/>
+      <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.valueSetVersion"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="PQR.originalText">
+      <path value="PQR.originalText"/>
+      <label value="Original Text"/>
+      <definition value="The text or phrase used as the basis for the coding."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="CD.originalText"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
+      </type>
+    </element>
+    <element id="PQR.qualifier">
+      <path value="PQR.qualifier"/>
+      <label value="Qualifier"/>
+      <definition value="Specifies additional codes that increase the specificity of the the primary code."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="CD.qualifier"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CR"/>
+      </type>
+    </element>
+    <element id="PQR.translation">
+      <path value="PQR.translation"/>
+      <label value="Translation"/>
+      <definition value="A set of other concept descriptors that translate this concept descriptor into other code systems."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="CD.translation"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="PQR">
       <path value="PQR"/>
-      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/><min value="1"/>
+      <definition value="A representation of a physical quantity in a unit from any code system. Used to show alternative representation for a physical quantity."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="PQR.value">

--- a/resources/QTY.xml
+++ b/resources/QTY.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="QTY"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="QTY">
       <path value="QTY"/>
-      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/><min value="1"/>
+      <short value="Quantity" />
+      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="QTY.nullFlavor">
       <path value="QTY.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -52,7 +54,8 @@
   <differential>
     <element id="QTY">
       <path value="QTY"/>
-      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/><min value="1"/>
+      <definition value="is an abstract generalization for all data types (1) whose value set has an order relation (less-or-equal) and (2) where difference is defined in all of the data type's totally ordered value subsets. The quantity type abstraction is needed in defining certain other types, such as the interval and the probability distribution."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
   </differential>

--- a/resources/REAL.xml
+++ b/resources/REAL.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="REAL"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="REAL">
       <path value="REAL"/>
-      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/><min value="1"/>
+      <short value="Real Number" />
+      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="REAL.nullFlavor">
       <path value="REAL.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -67,7 +69,8 @@
   <differential>
     <element id="REAL">
       <path value="REAL"/>
-      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/><min value="1"/>
+      <definition value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers. The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &#34;Real number&#34; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="REAL.value">

--- a/resources/RTO_PQ_PQ.xml
+++ b/resources/RTO_PQ_PQ.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="RTO_PQ_PQ"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,11 +19,12 @@
   <snapshot>
     <element id="RTO_PQ_PQ">
       <path value="RTO_PQ_PQ"/>
+      <short value="Ratio of Physical Quantities" />
       <definition value="A ratio of a physical quantity (PQ) numerator and a physical quantity (PQ) denominator."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="RTO_PQ_PQ.nullFlavor">
       <path value="RTO_PQ_PQ.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>

--- a/resources/SC.xml
+++ b/resources/SC.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="SC"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="SC">
       <path value="SC"/>
-      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/><min value="1"/>
+      <short value="Character String with Code" />
+      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="SC.nullFlavor">
       <path value="SC.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -47,21 +49,6 @@
         <strength value="required"/>
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
-    </element>
-    <element id="ST.value">
-      <path value="SC.value"/>
-      <representation value="xmlText"/>
-      <definition value="The string value"/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ST.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="SC.code">
       <path value="SC.code"/>
@@ -143,11 +130,27 @@
         <code value="string"/>
       </type>
     </element>
+    <element id="SC.value">
+      <path value="SC.value"/>
+      <representation value="xmlText"/>
+      <definition value="The string value"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ST.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
   </snapshot>
   <differential>
     <element id="SC">
       <path value="SC"/>
-      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/><min value="1"/>
+      <definition value="An ST that optionally may have a code attached. The text must always be present if a code is present. The code is often a local code."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
     <element id="SC.code">

--- a/resources/ST.xml
+++ b/resources/ST.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ST"/>
   <text>
@@ -25,10 +25,12 @@
   <snapshot>
     <element id="ST">
       <path value="ST"/>
-      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/><min value="1"/>
+      <short value="Character String" />
+      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
+      <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="ST.nullFlavor">
       <path value="ST.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -48,39 +50,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="ST.representation">
-      <path value="ST.representation"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.representation"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="TXT"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.mediaType">
-      <path value="ST.mediaType"/>
-      <representation value="xmlAttr"/>
-      <label value="Media Type"/>
-      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.mediaType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <fixedCode value="text/plain"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
     <element id="ST.charset">
       <path value="ST.charset"/>
       <representation value="xmlAttr"/>
@@ -90,22 +59,6 @@
       <max value="1"/>
       <base>
         <path value="ED.charset"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.language">
-      <path value="ST.language"/>
-      <representation value="xmlAttr"/>
-      <label value="Language"/>
-      <definition value="For character based information the language property specifies the human language of the text."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ED.language"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -169,6 +122,55 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
+    <element id="ST.language">
+      <path value="ST.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.language"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.mediaType"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="text/plain"/>
+    </element>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the representation of the binary data that is the content of the binary data value."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ED.representation"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="TXT"/>
+    </element>
     <element id="ST.data">
       <path value="ST.data"/>
       <representation value="xmlText"/>
@@ -218,47 +220,15 @@
   <differential>
     <element id="ST">
       <path value="ST"/>
-      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/><min value="1"/>
+      <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
+      <min value="1"/>
       <max value="*"/>
-    </element>
-    <element id="ST.representation">
-      <path value="ST.representation"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <fixedCode value="TXT"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.mediaType">
-      <path value="ST.mediaType"/>
-      <representation value="xmlAttr"/>
-      <label value="Media Type"/>
-      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
-      <min value="0"/>
-      <max value="1"/>
-      <fixedCode value="text/plain"/>
-      <type>
-        <code value="code"/>
-      </type>
     </element>
     <element id="ST.charset">
       <path value="ST.charset"/>
       <representation value="xmlAttr"/>
       <label value="Charset"/>
       <definition value="For character-based encoding types, this property specifies the character set and character encoding used. The charset shall be identified by an Internet Assigned Numbers Authority (IANA) Charset Registration [] in accordance with RFC 2978 []."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.language">
-      <path value="ST.language"/>
-      <representation value="xmlAttr"/>
-      <label value="Language"/>
-      <definition value="For character based information the language property specifies the human language of the text."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -305,6 +275,39 @@
         <strength value="required"/>
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
+    </element>
+    <element id="ST.language">
+      <path value="ST.language"/>
+      <representation value="xmlAttr"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
+      <representation value="xmlAttr"/>
+      <label value="Media Type"/>
+      <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="text/plain"/>
+    </element>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="TXT"/>
     </element>
     <element id="ST.data">
       <path value="ST.data"/>

--- a/resources/SXCM_TS.xml
+++ b/resources/SXCM_TS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="SXCM_TS"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,11 +19,12 @@
   <snapshot>
     <element id="SXCM_TS">
       <path value="SXCM_TS"/>
-      <definition value="Speciolization for timing specification of generic type extension for the base data type of a set, representing a component of a general set over a discrete or continuous value domain. Its use is mainly for continuous value domains. Discrete (enumerable) set components are the individual elements of the base data type."/>
+      <short value="Set Component for Timestamp" />
+      <definition value="Specialization for timing specification of generic type extension for the base data type of a set, representing a component of a general set over a discrete or continuous value domain. Its use is mainly for continuous value domains. Discrete (enumerable) set components are the individual elements of the base data type." />
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="SXCM_TS.nullFlavor">
       <path value="SXCM_TS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -43,25 +44,7 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="TS.value">
-      <extension url="http://www.healthintersections.com.au/fhir/StructureDefinition/elementdefinition-dateformat">
-        <valueString value="v3"/>
-      </extension>
-      <path value="SXCM_TS.value"/>
-      <representation value="xmlAttr"/>
-      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="TS.value"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="dateTime"/>
-      </type>
-    </element>
-    <element id="TS.inclusive">
+    <element id="SXCM_TS.inclusive">
       <path value="SXCM_TS.inclusive"/>
       <representation value="xmlAttr"/>
       <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
@@ -89,6 +72,24 @@
       </base>
       <type>
         <code value="code"/>
+      </type>
+    </element>
+    <element id="SXCM_TS.value">
+      <extension url="http://www.healthintersections.com.au/fhir/StructureDefinition/elementdefinition-dateformat">
+        <valueString value="v3"/>
+      </extension>
+      <path value="SXCM_TS.value"/>
+      <representation value="xmlAttr"/>
+      <definition value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="TS.value"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="dateTime"/>
       </type>
     </element>
   </snapshot>

--- a/resources/SXPR_TS.xml
+++ b/resources/SXPR_TS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="SXPR_TS"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
@@ -19,11 +19,12 @@
   <snapshot>
     <element id="SXPR_TS">
       <path value="SXPR_TS"/>
-      <definition value="A set-component that is itself made up of set-components that are evaluated as one value."></definition>
+      <short value="Parenthetic Set Expression for Timestamp" />
+      <definition value="A set-component that is itself made up of set-components that are evaluated as one value." />
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="SXPR_TS.nullFlavor">
       <path value="SXPR_TS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
@@ -43,7 +44,37 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
-    <element id="TS.value">
+    <element id="SXPR_TS.inclusive">
+      <path value="SXPR_TS.inclusive"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="TS.inclusive"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
+    <element id="SXPR_TS.operator">
+      <path value="SXPR_TS.operator"/>
+      <representation value="xmlAttr"/>
+      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="SXCM_TS.operator"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+    <element id="SXPR_TS.value">
       <extension url="http://www.healthintersections.com.au/fhir/StructureDefinition/elementdefinition-dateformat">
         <valueString value="v3"/>
       </extension>
@@ -61,38 +92,8 @@
         <code value="dateTime"/>
       </type>
     </element>
-    <element id="TS.inclusive">
-      <path value="SXPR_TS.inclusive"/>
-      <representation value="xmlAttr"/>
-      <definition value="Specifies whether the limit is included in the interval (interval is closed) or excluded from the interval (interval is open)."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="TS.inclusive"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="SXCM_TS.operator">
-      <path value="SXPR_TS.operator"/>
-      <representation value="xmlAttr"/>
-      <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="SXCM_TS.operator"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="SXPR_TS.comp">
-      <path value="SXPR_TS.comp"/>
+    <element id="SXPR_TS.comp[x]">
+      <path value="SXPR_TS.comp[x]" />
       <representation value="typeAttr"/>
       <definition value="comp is represented by the XML element comp which, if present, must be a valid SXCM"/>
       <min value="1"/>
@@ -122,8 +123,8 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXPR_TS.comp">
-      <path value="SXPR_TS.comp"/>
+    <element id="SXPR_TS.comp[x]">
+      <path value="SXPR_TS.comp[x]"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="*"/>

--- a/resources/ServiceEvent.xml
+++ b/resources/ServiceEvent.xml
@@ -133,7 +133,7 @@
     </element>
     <element id="ServiceEvent.code">
       <path value="ServiceEvent.code"/>
-      <definition value="Drawn from concept domain ActServiceEventCode"/>
+      <definition value="Drawn from concept domain ActCode"/>
       <min value="0"/>
       <max value="1"/>
       <base>
@@ -319,7 +319,7 @@
     </element>
     <element id="ServiceEvent.code">
       <path value="ServiceEvent.code"/>
-      <definition value="Drawn from concept domain ActServiceEventCode"/>
+      <definition value="Drawn from concept domain ActCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/resources/TEL.xml
+++ b/resources/TEL.xml
@@ -29,7 +29,7 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="TEL.nullFlavor">
       <path value="TEL.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>

--- a/resources/TN.xml
+++ b/resources/TN.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="TN"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>A restriction of entity name that is effectively a simple string used for a simple name for things and places.</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-xml-no-order">
+    <valueBoolean value="true"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/TN"/>
+  <name value="TN"/>
+  <title value="TN: TrivialName (V3 Data Type)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A restriction of entity name that is effectively a simple string used for a simple name for things and places."/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="TN"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+  <derivation value="specialization"/>
+  <snapshot>
+    <element id="TN">
+      <path value="TN"/>
+      <definition value="A restriction of entity name that is effectively a simple string used for a simple name for things and places."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="TN.nullFlavor">
+      <path value="TN.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="TN.delimiter">
+      <path value="TN.delimiter"/>
+      <definition value="A delimiter has no meaning other than being literally printed in this name representation. A delimiter has no implicit leading and trailing white space."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.delimiter"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="TN.family">
+      <path value="TN.family"/>
+      <definition value="Family name, this is the name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.family"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="TN.given">
+      <path value="TN.given"/>
+      <definition value="Given name (don't call it &quot;first name&quot; since this given names do not always come first)"/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.given"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="TN.prefix">
+      <path value="TN.prefix"/>
+      <definition value="A prefix has a strong association to the immediately following name part. A prefix has no implicit trailing white space (it has implicit leading white space though). Note that prefixes can be inverted."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.prefix"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="TN.suffix">
+      <path value="TN.suffix"/>
+      <definition value="A suffix has a strong association to the immediately preceding name part. A prefix has no implicit leading white space (it has implicit trailing white space though). Suffices can not be inverted."/>
+      <min value="0"/>
+      <max value="0"/>
+      <base>
+        <path value="EN.suffix"/>
+        <min value="0"/>
+        <max value="0"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ENXP"/>
+      </type>
+    </element>
+    <element id="TN.other">
+      <path value="TN.other"/>
+      <definition value="Unstructured textual represention of the entity name"/>
+      <representation value="xmlText"/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.other"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="TN.use">
+      <path value="TN.use"/>
+      <representation value="xmlAttr"/>
+      <label value="Use Code"/>
+      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="EN.use"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNameUse"/>
+      </binding>
+    </element>
+    <element id="TN.validTime">
+      <path value="TN.validTime"/>
+      <label value="Valid Time"/>
+      <definition value="An interval of time specifying the time during which the name is or was used for the entity. This accomodates the fact that people change names for people, places and things."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="EN.validTime"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
+      </type>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="TN">
+      <path value="TN"/>
+      <definition value="A restriction of entity name that is effectively a simple string used for a simple name for things and places."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="TN.delimiter">
+      <path value="TN.delimiter"/>
+      <min value="0"/>
+      <max value="0"/>
+    </element>
+    <element id="TN.family">
+      <path value="TN.family"/>
+      <min value="0"/>
+      <max value="0"/>
+    </element>
+    <element id="TN.given">
+      <path value="TN.given"/>
+      <min value="0"/>
+      <max value="0"/>
+    </element>
+    <element id="TN.prefix">
+      <path value="TN.prefix"/>
+      <min value="0"/>
+      <max value="0"/>
+    </element>
+    <element id="TN.suffix">
+      <path value="TN.suffix"/>
+      <min value="0"/>
+      <max value="0"/>
+    </element>
+    <element id="TN.use">
+      <path value="TN.use"/>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNameUse"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/TS.xml
+++ b/resources/TS.xml
@@ -32,7 +32,7 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ANY.nullFlavor">
+    <element id="TS.nullFlavor">
       <path value="TS.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>


### PR DESCRIPTION
1. Retained element/base definitions. Forge deletes those. 
2. Saving fixed certain ordering problems introduced in a previous commit. 
3. Add new datatypes ENXP, ON, PN, TN. 
4. Rearranged order for datatypes: attributes, text, elements. First attribute is nullFlavor, rest is alphabetical. element order as appears in datatypes XSD. This new order should help derived logical modeling